### PR TITLE
CompatHelper: add new compat entry for MAT at version 0.10, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 FFTW = "1"
+MAT = "0.10"
 julia = "1.6.7"
 
 [extras]


### PR DESCRIPTION
This pull request sets the compat entry for the `MAT` package to `0.10`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.