### PR TITLE
CompatHelper: add new compat entry for CSV at version 0.10, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
+CSV = "0.10"
 FFTW = "1"
 julia = "1.6.7"
 


### PR DESCRIPTION
This pull request sets the compat entry for the `CSV` package to `0.10`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.