### PR TITLE
if physicell repo dirty, add -dirty to hash

### DIFF
--- a/src/VCTClasses.jl
+++ b/src/VCTClasses.jl
@@ -236,10 +236,11 @@ function Monad(min_length::Int, folder_ids::AbstractSamplingIDs, folder_names::A
         monad_id = constructSelectQuery(
             "monads",
             """
-            WHERE (config_id,rulesets_collection_id,ic_cell_id,ic_substrate_id,\
+            WHERE (physicell_version_id,config_id,rulesets_collection_id,ic_cell_id,ic_substrate_id,\
             ic_ecm_id,custom_code_id,\
             $(join([string(field) for field in fieldnames(VariationIDs)],",")))=\
             (\
+                $(physicellVersionDBEntry()),\
                 $(folder_ids.config_id),$(folder_ids.rulesets_collection_id),\
                 $(folder_ids.ic_cell_id),$(folder_ids.ic_substrate_id),\
                 $(folder_ids.ic_ecm_id),$(folder_ids.custom_code_id),\
@@ -400,7 +401,7 @@ function Sampling(monad_min_length::Int, monad_ids::AbstractVector{<:Integer}, f
         (\
             $(physicellVersionDBEntry()),$(folder_ids.config_id),$(folder_ids.rulesets_collection_id),$(folder_ids.ic_cell_id),$(folder_ids.ic_substrate_id),$(folder_ids.ic_ecm_id),$(folder_ids.custom_code_id)\
         );\
-        """,
+        """;
         selection="sampling_id"
     ) |> queryToDataFrame |> x -> x.sampling_id
     if !isempty(sampling_ids) # if there are previous samplings with the same parameters
@@ -417,8 +418,8 @@ function Sampling(monad_min_length::Int, monad_ids::AbstractVector{<:Integer}, f
         id = DBInterface.execute(db, 
         """
         INSERT INTO samplings \
-        (config_id,rulesets_collection_id,ic_cell_id,ic_substrate_id,ic_ecm_id,custom_code_id) \
-        VALUES($(folder_ids.config_id),$(folder_ids.rulesets_collection_id),\
+        (physicell_version_id,config_id,rulesets_collection_id,ic_cell_id,ic_substrate_id,ic_ecm_id,custom_code_id) \
+        VALUES($(physicellVersionDBEntry()),$(folder_ids.config_id),$(folder_ids.rulesets_collection_id),\
         $(folder_ids.ic_cell_id),$(folder_ids.ic_substrate_id),\
         $(folder_ids.ic_ecm_id),$(folder_ids.custom_code_id)) RETURNING sampling_id;
         """

--- a/src/VCTDatabase.jl
+++ b/src/VCTDatabase.jl
@@ -35,6 +35,7 @@ function createSchema(is_new_db::Bool; auto_upgrade::Bool=false)
 
     # initialize and populate physicell_versions table
     createPCVCTTable("physicell_versions", physicellVersionsSchema())
+    global current_physicell_version_id = physicellVersionID()
 
     # initialize and populate custom_codes table
     custom_codes_schema = """

--- a/src/VCTModule.jl
+++ b/src/VCTModule.jl
@@ -88,7 +88,6 @@ function initializeVCT(path_to_physicell::String, path_to_data::String; auto_upg
         println("Database initialization failed.")
         return
     end
-    global current_physicell_version_id = physicellVersionID()
     println(rpad("PhysiCell version:", 20, ' ') * physicellVersion())
     println(rpad("pcvct version:", 20, ' ') * string(pcvctVersion()))
     println(rpad("Compiler:", 20, ' ') * PHYSICELL_CPP)

--- a/src/VCTRunner.jl
+++ b/src/VCTRunner.jl
@@ -119,7 +119,8 @@ function runTrial(trial::Trial; force_recompile::Bool=true, prune_options::Prune
     return simulation_tasks
 end
 
-collectSimulationTasks(simulation::Simulation; force_recompile::Bool=false, prune_options::PruneOptions=PruneOptions()) = [@task runSimulation(simulation; do_full_setup=true, force_recompile=force_recompile, prune_options=prune_options)]
+collectSimulationTasks(simulation::Simulation; force_recompile::Bool=false, prune_options::PruneOptions=PruneOptions()) = 
+    isStarted(simulation) ? Task[] : [@task runSimulation(simulation; do_full_setup=true, force_recompile=force_recompile, prune_options=prune_options)]
 collectSimulationTasks(monad::Monad; force_recompile::Bool=false, prune_options::PruneOptions=PruneOptions()) = runMonad(monad; do_full_setup=true, force_recompile=force_recompile, prune_options=prune_options)
 collectSimulationTasks(sampling::Sampling; force_recompile::Bool=false, prune_options::PruneOptions=PruneOptions()) = runSampling(sampling; force_recompile=force_recompile, prune_options=prune_options)
 collectSimulationTasks(trial::Trial; force_recompile::Bool=false, prune_options::PruneOptions=PruneOptions()) = runTrial(trial; force_recompile=force_recompile, prune_options=prune_options)

--- a/src/VCTUp.jl
+++ b/src/VCTUp.jl
@@ -1,6 +1,6 @@
 function upgradePCVCT(from_version::VersionNumber, to_version::VersionNumber, auto_upgrade::Bool)
     println("Upgrading pcvct from version $(from_version) to $(to_version)...")
-    milestone_versions = [v"0.0.1", v"0.0.3", v"0.0.10"]
+    milestone_versions = [v"0.0.1", v"0.0.3", v"0.0.10", v"0.0.11"]
     next_milestone_inds = findall(x -> from_version < x, milestone_versions) # this could be simplified to take advantage of this list being sorted, but who cares? It's already so fast
     next_milestones = milestone_versions[next_milestone_inds]
     success = true
@@ -195,4 +195,24 @@ function upgradeToV0_0_10(auto_upgrade::Bool)
         DBInterface.execute(db, "UPDATE samplings SET physicell_version_id=$(physicellVersionDBEntry());")
     end
     return true
+end
+
+function upgradeToV0_0_11(::Bool)
+    println("\t- Upgrading to version 0.0.11...")
+    query = constructSelectQuery("samplings")
+    samplings_df = queryToDataFrame(query)
+    for row in eachrow(samplings_df)
+        if !ismissing(row.physicell_version_id)
+            continue
+        end
+        monads = getMonadIDs(Sampling(row.sampling_id))
+        query = constructSelectQuery("monads", "WHERE monad_id IN ($(join(monads, ",")))"; selection="physicell_version_id")
+        monads_df = queryToDataFrame(query)
+        monad_physicell_versions = monads_df.physicell_version_id |> unique
+        if length(monad_physicell_versions) == 1
+            DBInterface.execute(db, "UPDATE samplings SET physicell_version_id=$(monad_physicell_versions[1]) WHERE sampling_id=$(row.sampling_id);")
+        else
+            println("WARNING: Multiple PhysiCell versions found for monads in sampling $(row.sampling_id). Not setting the sampling PhysiCell version.")
+        end
+    end
 end

--- a/src/VCTVersion.jl
+++ b/src/VCTVersion.jl
@@ -36,7 +36,7 @@ function resolvePCVCTVersion(is_new_db::Bool, auto_upgrade::Bool)
 
     if pcvct_version < pcvct_db_version
         msg = """
-        The pcvct version is $(pcvct_version) but the database version is $(pcvct_db_version).\
+        The pcvct version is $(pcvct_version) but the database version is $(pcvct_db_version). \
         Upgrade your pcvct version to $(pcvct_db_version) or higher:
             pkg> registry add https://github.com/drbergman/PCVCTRegistry
             pkg> registry up PCVCTRegistry


### PR DESCRIPTION
- NULL in the index are no equal when compared. so instead fill out the commit hash with "$(commit_hash)-dirty"
- this will allow for unreproducible results, but gives the user the flexibility to work with a dirty repo
- it fixes the behavior where NULLs caused extra simulations and monads because they did not match

big bug fixes for physicell version
- monads and samplings, when selected, did not consider physicell version
- set global current_physicell_version_id inside createSchema so the db grabs the PhysiCell version on resetDatabase
- better warning message for dirty repos
- collectSimulationTasks(simulation::Simulation) only runs the sim if it is !isStarted (just like runMonad does)
- auto-upgrade to v0.0.11