### PR TITLE
support sbatch on hpc

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,13 +83,13 @@ jobs:
     - name: Run all tests
       uses: julia-actions/julia-runtest@v1
       env:
-        JULIA_NUM_THREADS: 8
+        PCVCT_NUM_PARALLEL_SIMS: 8
         PHYSICELL_CPP: ${{ matrix.compiler }} # maybe necessary for windows??
         PCVCT_PUBLIC_REPO_AUTH: ${{ secrets.PUBLIC_REPO_AUTH }}
     - uses: julia-actions/julia-processcoverage@v1
     - uses: codecov/codecov-action@v5
       with:
-        file: lcov.info
+        files: lcov.info
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
         

--- a/docs/src/lib/VCTDatabase.md
+++ b/docs/src/lib/VCTDatabase.md
@@ -1,0 +1,12 @@
+```@meta
+CollapsedDocStrings = true
+```
+
+# VCTDatabase
+
+This file holds the functions for the VCT database.
+
+```@autodocs
+Modules = [pcvct]
+Pages = ["VCTDatabase.jl"]
+```

--- a/docs/src/lib/VCTHPC.md
+++ b/docs/src/lib/VCTHPC.md
@@ -1,0 +1,12 @@
+```@meta
+CollapsedDocStrings = true
+```
+
+# VCTHPC
+
+This file holds functionality for running pcvct on an HPC.
+
+```@autodocs
+Modules = [pcvct]
+Pages = ["VCTHPC.jl"]
+```

--- a/src/VCTAnalysis/population.jl
+++ b/src/VCTAnalysis/population.jl
@@ -47,7 +47,7 @@ end
 
 function SimulationPopulationTimeSeries(simulation_id::Integer; include_dead::Bool=false)
     print("Computing SimulationPopulationTimeSeries for Simulation $simulation_id...")
-    simulation_folder = joinpath(data_dir, "outputs", "simulations", string(simulation_id))
+    simulation_folder = outputFolder("simulation", simulation_id)
     path_to_summary = joinpath(simulation_folder, "summary")
     path_to_file = joinpath(path_to_summary, "population_time_series$(include_dead ? "_include_dead" : "").csv")
     if isfile(path_to_file)
@@ -74,7 +74,7 @@ function finalPopulationCount(folder::String; include_dead::Bool=false)
 end
 
 function finalPopulationCount(simulation_id::Int; include_dead::Bool=false)
-    return joinpath(data_dir, "outputs", "simulations", string(simulation_id), "output") |> x -> finalPopulationCount(x; include_dead=include_dead)
+    return joinpath(outputFolder("simulation", simulation_id), "output") |> x -> finalPopulationCount(x; include_dead=include_dead)
 end
 
 struct MonadPopulationTimeSeries <: AbstractPopulationTimeSeries

--- a/src/VCTAnalysis/substrate.jl
+++ b/src/VCTAnalysis/substrate.jl
@@ -46,7 +46,7 @@ end
 
 function AverageSubstrateTimeSeries(simulation_id::Integer)
     print("Computing average substrate time series for Simulation $simulation_id...")
-    simulation_folder = joinpath(data_dir, "outputs", "simulations", string(simulation_id))
+    simulation_folder = outputFolder("simulation", simulation_id)
     path_to_summary = joinpath(simulation_folder, "summary")
     path_to_file = joinpath(path_to_summary, "average_substrate_time_series.csv")
     if isfile(path_to_file)
@@ -143,7 +143,7 @@ end
 
 function ExtracellularSubstrateTimeSeries(simulation_id::Integer; include_dead::Bool=false)
     print("Computing extracellular substrate time series for Simulation $simulation_id...")
-    simulation_folder = joinpath(data_dir, "outputs", "simulations", string(simulation_id))
+    simulation_folder = outputFolder("simulation", simulation_id)
     path_to_summary = joinpath(simulation_folder, "summary")
     path_to_file = joinpath(path_to_summary, "extracellular_substrate_time_series$(include_dead ? "_include_dead" : "").csv")
     if isfile(path_to_file)

--- a/src/VCTClasses.jl
+++ b/src/VCTClasses.jl
@@ -590,9 +590,9 @@ function Trial(samplings::Vector{Sampling})
     return Trial(monad_min_length, sampling_ids, folder_ids, folder_names, variation_ids)
 end
 
-function Trial(; monad_min_length::Int=0, sampling_ids::AbstractArray{<:Integer}=Int[], config_folders::Vector{String}=String[],
-                rulesets_collection_folders::Vector{String}=String[], ic_cell_folders::Vector{String}=String[], 
-                ic_substrate_folders::Vector{String}=String[], ic_ecm_folders::Vector{String}=String[], custom_code_folders::Vector{String}=String[],
+function Trial(; monad_min_length::Int=0, sampling_ids::AbstractArray{<:Integer}=Int[], config_folders::Vector{<:AbstractString}=String[],
+                rulesets_collection_folders::Vector{<:AbstractString}=String[], ic_cell_folders::Vector{<:AbstractString}=String[], 
+                ic_substrate_folders::Vector{<:AbstractString}=String[], ic_ecm_folders::Vector{<:AbstractString}=String[], custom_code_folders::Vector{<:AbstractString}=String[],
                 config_variation_ids::AbstractArray{<:AbstractArray{<:Integer}}=AbstractArray{<:Integer}[],
                 rulesets_variation_ids::AbstractArray{<:AbstractArray{<:Integer}}=AbstractArray{<:Integer}[],
                 ic_cell_variation_ids::AbstractArray{<:AbstractArray{<:Integer}}=AbstractArray{<:Integer}[],

--- a/src/VCTCompilation.jl
+++ b/src/VCTCompilation.jl
@@ -9,21 +9,10 @@ Load and compile custom code for a given sampling instance.
 - `force_recompile::Bool=false`: A boolean flag to force recompilation of the custom code regardless of the current state.
 
 # Description
-This function performs the following steps:
-1. Retrieves compiler flags and determines if recompilation is necessary.
-2. If recompilation is not required and `force_recompile` is false, the function returns immediately.
-3. If recompilation is required, it optionally cleans the build directory.
-4. Copies custom module files, `main.cpp`, and `Makefile` from the source directory to the target directory.
-5. Compiles the custom code using the `make` command with appropriate flags.
-6. Logs the compilation output and errors to specified files.
-7. Deletes the error log file if it is empty.
-8. Cleans up by removing copied files and restoring the default `Makefile`.
-9. Moves the compiled project to the designated folder.
-
-# Notes
-- The function assumes the presence of specific directory structures and file names.
-- On macOS, the `-j` flag is used to parallelize the compilation process.
-- The function logs compilation output and errors to files in the source directory.
+This function determines if recompilation is necessary based on the previously used macros.
+If compilation is required, it copies the PhysiCell directory to a temporary directory to avoid conflicts.
+It then compiles the project, recording the output and error in the `custom_codes` folder used.
+The compiled executable is then moved into the `custom_codes` folder and the temporary PhysiCell folder deleted.
 """
 function loadCustomCode(S::AbstractSampling; force_recompile::Bool=false)
     cflags, recompile, clean = getCompilerFlags(S)
@@ -31,26 +20,27 @@ function loadCustomCode(S::AbstractSampling; force_recompile::Bool=false)
     recompile |= force_recompile # if force_recompile is true, then recompile no matter what
 
     if !recompile
-        return
+        return true
     end
-
-    # at some point, should "lock" this function until any other compilations are complete...ideally a way that is independent of the current runtime
 
     if clean
         cd(()->run(pipeline(`make clean`; stdout=devnull)), physicell_dir)
     end
+    
+    rand_suffix = randstring(10) # just to ensure that no two nodes try to compile at the same place at the same time
+    temp_physicell_dir = joinpath(outputFolder(S), "temp_physicell_$(rand_suffix)")
+    # copy the entire PhysiCell directory to a temporary directory to avoid conflicts with concurrent compilation
+    cp(physicell_dir, temp_physicell_dir; force=true)
 
-    path_to_folder = joinpath(data_dir, "inputs", "custom_codes", S.folder_names.custom_code_folder) # source dir needs to end in / or else the dir is copied into target, not the source files
-    for file in readdir(joinpath(path_to_folder, "custom_modules"), sort=false)
-        if !isfile(joinpath(path_to_folder, "custom_modules", file))
-            continue
-        end
-        src = joinpath(path_to_folder, "custom_modules", file)
-        dst = joinpath(physicell_dir, "custom_modules", file)
-        cp(src, dst, force=true)
+    temp_custom_modules_dir = joinpath(temp_physicell_dir, "custom_modules")
+    if isdir(temp_custom_modules_dir)
+        rm(temp_custom_modules_dir; force=true, recursive=true)
     end
-    cp(joinpath(path_to_folder, "main.cpp"), joinpath(physicell_dir, "main.cpp"), force=true)
-    cp(joinpath(path_to_folder, "Makefile"), joinpath(physicell_dir, "Makefile"), force=true)
+    path_to_input_custom_codes = joinpath(data_dir, "inputs", "custom_codes", S.folder_names.custom_code_folder)
+    cp(joinpath(path_to_input_custom_codes, "custom_modules"), temp_custom_modules_dir; force=true)
+
+    cp(joinpath(path_to_input_custom_codes, "main.cpp"), joinpath(temp_physicell_dir, "main.cpp"), force=true)
+    cp(joinpath(path_to_input_custom_codes, "Makefile"), joinpath(temp_physicell_dir, "Makefile"), force=true)
 
     executable_name = baseToExecutable("project_ccid_$(S.folder_ids.custom_code_id)")
     cmd = `make CC=$(PHYSICELL_CPP) PROGRAM_NAME=$(executable_name) CFLAGS=$(cflags)`
@@ -60,20 +50,29 @@ function loadCustomCode(S::AbstractSampling; force_recompile::Bool=false)
 
     println("Compiling custom code for $(S.folder_names.custom_code_folder) with flags: $cflags")
 
-    cd(() -> run(pipeline(cmd; stdout=joinpath(path_to_folder, "compilation.log"), stderr=joinpath(path_to_folder, "compilation.err"))), physicell_dir) # compile the custom code in the PhysiCell directory and return to the original directory; make sure the macro ADDON_PHYSIECM is defined (should work even if multiply defined, e.g., by Makefile)
+    try
+        cd(() -> run(pipeline(cmd; stdout=joinpath(path_to_input_custom_codes, "compilation.log"), stderr=joinpath(path_to_input_custom_codes, "compilation.err"))), temp_physicell_dir) # compile the custom code in the PhysiCell directory and return to the original directory
+    catch e
+        println("""
+        Compilation failed. 
+        Error: $e
+        Check $(joinpath(path_to_input_custom_codes, "compilation.err")) for more information.
+        """
+        )
+        return false
+    end
     
     # check if the error file is empty, if it is, delete it
-    if filesize(joinpath(path_to_folder, "compilation.err")) == 0
-        rm(joinpath(path_to_folder, "compilation.err"); force=true)
+    if filesize(joinpath(path_to_input_custom_codes, "compilation.err")) == 0
+        rm(joinpath(path_to_input_custom_codes, "compilation.err"); force=true)
+    else
+        println("Compilation exited without error, but check $(joinpath(path_to_input_custom_codes, "compilation.err")) for warnings.")
     end
 
-    rm(joinpath(physicell_dir, "custom_modules", "custom.cpp"); force=true)
-    rm(joinpath(physicell_dir, "custom_modules", "custom.h"); force=true)
-    rm(joinpath(physicell_dir, "main.cpp"); force=true)
-    cp(joinpath(physicell_dir, "sample_projects", "Makefile-default"), joinpath(physicell_dir, "Makefile"), force=true)
+    mv(joinpath(temp_physicell_dir, executable_name), joinpath(path_to_input_custom_codes, baseToExecutable("project")), force=true)
 
-    mv(joinpath(physicell_dir, executable_name), joinpath(data_dir, "inputs", "custom_codes", S.folder_names.custom_code_folder, baseToExecutable("project")), force=true)
-    return 
+    rm(temp_physicell_dir; force=true, recursive=true)
+    return true
 end
 
 """
@@ -90,17 +89,13 @@ Generate the compiler flags for the given sampling object `S`.
 - `clean::Bool`: A boolean indicating whether cleaning is needed.
 
 # Description
-This function generates the necessary compiler flags based on the system and the macros defined in the sampling object `S`. It checks if the system is macOS and adjusts the flags accordingly. It also compares the current macros with the updated macros to determine if recompilation and cleaning are needed.
-
-# Notes
-- On macOS, it checks if the system architecture is `arm64` and adjusts the `-mfpmath` flag accordingly.
-- It reads the current macros from a file and compares them with the updated macros to decide if recompilation and cleaning are necessary.
-- If the project file does not exist in the specified directory, it sets `recompile` to `true`.
+This function generates the necessary compiler flags based on the system and the macros defined in the sampling object `S`. \
+If the required macros differ from a previous compilation (as stored in macros.txt), then recompile.
 """
 function getCompilerFlags(S::AbstractSampling)
     recompile = false # only recompile if need is found
     clean = false # only clean if need is found
-    cflags = "-march=native -O3 -fomit-frame-pointer -fopenmp -m64 -std=c++11"
+    cflags = "-march=$(march_flag) -O3 -fomit-frame-pointer -fopenmp -m64 -std=c++11"
     if Sys.isapple()
         if strip(read(`uname -s`, String)) == "Darwin"
             cc_path = strip(read(`which $(PHYSICELL_CPP)`, String))
@@ -127,12 +122,12 @@ function getCompilerFlags(S::AbstractSampling)
         cflags *= " -D $(macro_flag)"
     end
 
-    if !recompile && !isfile(joinpath(data_dir, "inputs", "custom_codes", S.folder_names.custom_code_folder, baseToExecutable("project")))
-        recompile = true
-    end
+    recompile |= !executableExists(S.folder_names.custom_code_folder) # last chance to recompile: do so if the executable does not exist
 
     return cflags, recompile, clean
 end
+
+executableExists(custom_code_folder::String) = isfile(joinpath(data_dir, "inputs", "custom_codes", custom_code_folder, baseToExecutable("project")))
 
 function addMacrosIfNeeded(S::AbstractSampling)
     # else get the macros neeeded

--- a/src/VCTConfiguration.jl
+++ b/src/VCTConfiguration.jl
@@ -10,7 +10,7 @@ end
 
 closeXML(xml_doc::XMLDocument) = free(xml_doc)
 
-function retrieveElement(xml_doc::XMLDocument, xml_path::Vector{String}; required::Bool=true)
+function retrieveElement(xml_doc::XMLDocument, xml_path::Vector{<:AbstractString}; required::Bool=true)
     current_element = root(xml_doc)
     for path_element in xml_path
         if !occursin(":",path_element)
@@ -26,7 +26,7 @@ function retrieveElement(xml_doc::XMLDocument, xml_path::Vector{String}; require
         candidate_elements = get_elements_by_tagname(current_element, path_element_name)
         found = false
         for ce in candidate_elements
-            if attribute(ce,attribute_name)==attribute_value
+            if attribute(ce, attribute_name) == attribute_value
                 found = true
                 current_element = ce
                 break
@@ -39,24 +39,17 @@ function retrieveElement(xml_doc::XMLDocument, xml_path::Vector{String}; require
     return current_element
 end
 
-function retrieveElementError(xml_path::Vector{String}, path_element::String)
+function retrieveElementError(xml_path::Vector{<:AbstractString}, path_element::String)
     error_msg = "Element not found: $(join(xml_path, " -> "))"
     error_msg *= "\n\tFailed at: $(path_element)"
     throw(ArgumentError(error_msg))
 end
 
-function getField(xml_doc::XMLDocument, xml_path::Vector{String}; required::Bool=true)
+function getField(xml_doc::XMLDocument, xml_path::Vector{<:AbstractString}; required::Bool=true)
     return retrieveElement(xml_doc, xml_path; required=required) |> content
 end
 
-function getOutputFolder(path_to_xml)
-    xml_doc = openXML(path_to_xml)
-    rel_path_to_output = getField(xml_doc, ["save", "folder"])
-    closeXML(xml_doc)
-    return rel_path_to_output
-end
-
-function updateField(xml_doc::XMLDocument, xml_path::Vector{String}, new_value::Union{Int,Real,String})
+function updateField(xml_doc::XMLDocument, xml_path::Vector{<:AbstractString}, new_value::Union{Int,Real,String})
     current_element = retrieveElement(xml_doc, xml_path; required=true)
     set_content(current_element, string(new_value))
     return nothing
@@ -66,7 +59,7 @@ function updateField(xml_doc::XMLDocument, xml_path_and_value::Vector{Any})
     return updateField(xml_doc, xml_path_and_value[1:end-1],xml_path_and_value[end])
 end
 
-function multiplyField(xml_doc::XMLDocument, xml_path::Vector{String}, multiplier::AbstractFloat)
+function multiplyField(xml_doc::XMLDocument, xml_path::Vector{<:AbstractString}, multiplier::AbstractFloat)
     current_element = retrieveElement(xml_doc, xml_path; required=true)
     val = content(current_element)
     if attribute(current_element, "type"; required=false) == "int"
@@ -79,7 +72,7 @@ function multiplyField(xml_doc::XMLDocument, xml_path::Vector{String}, multiplie
     return nothing
 end
 
-function xmlPathToColumnName(xml_path::Vector{String})
+function xmlPathToColumnName(xml_path::Vector{<:AbstractString})
     return join(xml_path, "/")
 end
 
@@ -238,7 +231,7 @@ function customDataPath(cell_definition::String, field_name::String)::Vector{Str
     return [customDataPath(cell_definition); field_name]
 end
 
-function customDataPath(cell_definition::String, field_names::Vector{String})
+function customDataPath(cell_definition::String, field_names::Vector{<:AbstractString})
     return [customDataPath(cell_definition, field_name) for field_name in field_names]
 end
 
@@ -246,7 +239,7 @@ function userParameterPath(field_name::String)::Vector{String}
     return ["user_parameters"; field_name]
 end
 
-function userParameterPath(field_names::Vector{String})
+function userParameterPath(field_names::Vector{<:AbstractString})
     return [userParameterPath(field_name) for field_name in field_names]
 end
 
@@ -294,7 +287,7 @@ function addCustomDataVariationDimension!(AV::Vector{<:AbstractVariation}, cell_
     push!(AV, ElementaryVariation(xml_path, values))
 end
 
-function addCustomDataVariationDimension!(AV::Vector{<:AbstractVariation}, cell_definition::String, field_names::Vector{String}, values::Vector{Vector})
+function addCustomDataVariationDimension!(AV::Vector{<:AbstractVariation}, cell_definition::String, field_names::Vector{<:AbstractString}, values::Vector{Vector})
     for (field_name, value) in zip(field_names,values)
         addCustomDataVariationDimension!(EV, cell_definition, field_name, value)
     end

--- a/src/VCTDatabase.jl
+++ b/src/VCTDatabase.jl
@@ -328,6 +328,12 @@ function getStatusCodeID(status_code::String)
     return queryToDataFrame(query; is_row=true) |> x -> x[1,:status_code_id]
 end
 
+"""
+`isStarted(simulation_id::Int; new_status_code::Union{Missing,String}=missing)`
+Checks if a simulation has been started.
+If `new_status_code` is provided, then the status of the simulation is updated to this value.
+The check and status update are done in a transaction to ensure that the status is not changed by another process.
+"""
 function isStarted(simulation_id::Int; new_status_code::Union{Missing,String}=missing)
     query = constructSelectQuery("simulations", "WHERE simulation_id=$(simulation_id);"; selection="status_code_id")
     mode = ismissing(new_status_code) ? "DEFERRED" : "EXCLUSIVE" # if we are possibly going to update, then set to exclusive mode

--- a/src/VCTDeletion.jl
+++ b/src/VCTDeletion.jl
@@ -4,7 +4,7 @@ function deleteSimulation(simulation_ids::AbstractVector{<:Integer}; delete_supe
     simulation_ids = sim_df.simulation_id # update based on the constraints added
     DBInterface.execute(db,"DELETE FROM simulations WHERE simulation_id IN ($(join(simulation_ids,",")));")
     for row in eachrow(sim_df)
-        rm(joinpath(data_dir, "outputs", "simulations", string(row.simulation_id)); force=true, recursive=true)
+        rm(outputFolder("simulation", row.simulation_id); force=true, recursive=true)
 
         config_folder = configFolder(row.config_id)
         result_df = constructSelectQuery(
@@ -71,7 +71,7 @@ function deleteMonad(monad_ids::AbstractVector{<:Integer}; delete_subs::Bool=tru
         if delete_subs
             append!(simulation_ids_to_delete, readMonadSimulationIDs(monad_id))
         end
-        rm(joinpath(data_dir, "outputs", "monads", string(monad_id)); force=true, recursive=true)
+        rm(outputFolder("monad", monad_id); force=true, recursive=true)
     end
     if !isempty(simulation_ids_to_delete)
         deleteSimulation(simulation_ids_to_delete; delete_supers=false)
@@ -110,7 +110,7 @@ function deleteSampling(sampling_ids::AbstractVector{<:Integer}; delete_subs::Bo
         if delete_subs
             append!(monad_ids_to_delete, readSamplingMonadIDs(sampling_id))
         end
-        rm(joinpath(data_dir, "outputs", "samplings", string(sampling_id)); force=true, recursive=true)
+        rm(outputFolder("sampling", sampling_id); force=true, recursive=true)
     end
     if !isempty(monad_ids_to_delete)
         all_sampling_ids = constructSelectQuery("samplings"; selection="sampling_id") |> queryToDataFrame |> x -> x.sampling_id
@@ -158,7 +158,7 @@ function deleteTrial(trial_ids::AbstractVector{<:Integer}; delete_subs::Bool=tru
         if delete_subs
             append!(sampling_ids_to_delete, readTrialSamplingIDs(trial_id))
         end
-        rm(joinpath(data_dir, "outputs", "trials", string(trial_id)); force=true, recursive=true)
+        rm(outputFolder("trial", trial_id); force=true, recursive=true)
     end
     if !isempty(sampling_ids_to_delete)
         all_trial_ids = constructSelectQuery("trials"; selection="trial_id") |> queryToDataFrame |> x -> x.trial_id

--- a/src/VCTHPC.jl
+++ b/src/VCTHPC.jl
@@ -1,0 +1,42 @@
+function shellCommandExists(cmd::Union{String,Cmd})
+    p = run(ignorestatus(`which $cmd`))
+    return p.exitcode == 0
+end
+
+"""
+`isRunningOnHPC()`
+Returns `true` if the current environment is an HPC environment, `false` otherwise.
+Currently, this function checks if the `sbatch` command is available, indicating a SLURM environment.
+"""
+isRunningOnHPC() = shellCommandExists(`sbatch`)
+
+"""
+`useHPC(use::Bool=true)`
+Sets the global variable `run_on_hpc` to `use`.
+"""
+function useHPC(use::Bool=true)
+    global run_on_hpc = use
+end
+
+"""
+`defaultJobOptions()`
+Returns a dictionary with default options for a job script for use with SLURM.
+"""
+function defaultJobOptions()
+    return Dict(
+        "job-name" => simulation_id -> "S$(simulation_id)",
+        "mem" => "1G"
+    )
+end
+
+"""
+`setJobOptions(options::Dict)`
+Sets the default job options for use with SLURM.
+For any key-value pair in `options`, the corresponding key in the global `sbatch_options` dictionary is set to the value.
+A flag is then added to the sbatch command for each key-value pair in `options`: `--key=value`.
+"""
+function setJobOptions(options::Dict)
+    for (key, value) in options
+        global sbatch_options[key] = value
+    end
+end

--- a/src/VCTLoader.jl
+++ b/src/VCTLoader.jl
@@ -155,7 +155,7 @@ function PhysiCellSnapshot(folder::String, index::Union{Int, Symbol}; include_ce
     return PhysiCellSnapshot(folder, index, time, DataFrame(cells), substrates, mesh)
 end
 
-PhysiCellSnapshot(simulation_id::Integer, index::Union{Int, Symbol}; kwargs...) = PhysiCellSnapshot(joinpath(data_dir, "outputs", "simulations", string(simulation_id), "output"), index; kwargs...)
+PhysiCellSnapshot(simulation_id::Integer, index::Union{Int, Symbol}; kwargs...) = PhysiCellSnapshot(joinpath(outputFolder("simulation", simulation_id), "output"), index; kwargs...)
 
 function loadCells!(cells::DataFrame, filepath_base::String, cell_type_to_name_dict::Dict{Int, String}=Dict{Int, String}(), labels::Vector{String}=String[])
     if !isempty(cells)
@@ -346,7 +346,7 @@ function computeMeanSpeed(folder::String; direction=:any)::NTuple{3,Vector{Dict{
 end
 
 function computeMeanSpeed(simulation_id::Int; direction=:any)::NTuple{3,Vector{Dict{String,Float64}}}
-    return joinpath(data_dir, "outputs", "simulations", string(simulation_id), "output") |> x -> computeMeanSpeed(x; direction=direction)
+    return joinpath(outputFolder("simulation", simulation_id), "output") |> x -> computeMeanSpeed(x; direction=direction)
 end
 
 function computeMeanSpeed(class_id::Union{VCTClassID,AbstractTrial}; direction=:any)

--- a/src/VCTMovie.jl
+++ b/src/VCTMovie.jl
@@ -1,7 +1,7 @@
 export makeMovie
 
 function makeMovie(simulation_id::Int)
-    path_to_output_folder = joinpath(data_dir, "outputs", "simulations", string(simulation_id), "output")
+    path_to_output_folder = joinpath(outputFolder("simulation", simulation_id), "output")
     if isfile("$(path_to_output_folder)/out.mp4")
         movie_generated = false
         return movie_generated
@@ -13,10 +13,10 @@ function makeMovie(simulation_id::Int)
     cmd = Cmd(`make movie OUTPUT=$(path_to_output_folder)`; env=env)
     cd(() -> run(pipeline(cmd; stdout=devnull, stderr=devnull)), physicell_dir)
     movie_generated = true
-    jpgs = readdir(joinpath(data_dir, "outputs", "simulations", string(simulation_id), "output"), sort=false)
+    jpgs = readdir(joinpath(outputFolder("simulation", simulation_id), "output"), sort=false)
     filter!(f -> endswith(f, ".jpg"), jpgs)
     for jpg in jpgs
-        rm(joinpath(data_dir, "outputs", "simulations", string(simulation_id), "output", jpg))
+        rm(joinpath(outputFolder("simulation", simulation_id), "output", jpg))
     end
     return movie_generated
 end

--- a/src/VCTPhysiCellStudio.jl
+++ b/src/VCTPhysiCellStudio.jl
@@ -21,7 +21,7 @@ function runStudio(simulation_id::Int; python_path::Union{Missing,String}=path_t
         println("Setting path to studio to $path_to_studio")
     end
 
-    path_to_output = joinpath(data_dir, "outputs", "simulations", string(simulation_id), "output")
+    path_to_output = joinpath(outputFolder("simulation", simulation_id), "output")
     path_to_xml = joinpath(path_to_output, "PhysiCell_settings.xml")
     xml_doc = openXML(path_to_xml)
     updateField(xml_doc, ["save", "folder"], path_to_output)

--- a/src/VCTPruner.jl
+++ b/src/VCTPruner.jl
@@ -11,8 +11,8 @@ export PruneOptions
     prune_final::Bool = false
 end
 
-function pruneSimulationOutput(simulation::Simulation; prune_options::PruneOptions=PruneOptions())
-    path_to_output_folder = joinpath(data_dir, "outputs", "simulations", string(simulation.id), "output")
+function pruneSimulationOutput(simulation_id::Integer; prune_options::PruneOptions=PruneOptions())
+    path_to_output_folder = joinpath(outputFolder("simulation", simulation_id), "output")
     if prune_options.prune_svg
         glob("snapshot*.svg", path_to_output_folder) .|> x->rm(x, force=true)
         if prune_options.prune_initial
@@ -41,3 +41,5 @@ function pruneSimulationOutput(simulation::Simulation; prune_options::PruneOptio
         end
     end
 end
+
+pruneSimulationOutput(simulation::Simulation; prune_options::PruneOptions=PruneOptions()) = pruneSimulationOutput(simulation.id; prune_options=prune_options)

--- a/src/VCTRecorder.jl
+++ b/src/VCTRecorder.jl
@@ -6,25 +6,25 @@ function recordIDs(path_to_folder::String, filename::String, ids::Array{Int})
 end
 
 function recordSimulationIDs(monad_id::Int, simulation_ids::Array{Int})
-    path_to_folder = joinpath(data_dir, "outputs", "monads", string(monad_id))
+    path_to_folder = outputFolder("monad", monad_id)
     recordIDs(path_to_folder, "simulations", simulation_ids)
 end
 
 recordSimulationIDs(monad::Monad) = recordSimulationIDs(monad.id, monad.simulation_ids)
 
 function recordMonadIDs(sampling_id::Int, monad_ids::Array{Int})
-    path_to_folder = joinpath(data_dir, "outputs", "samplings", string(sampling_id))
+    path_to_folder = outputFolder("sampling", sampling_id)
     recordIDs(path_to_folder, "monads", monad_ids)
 end
 
 recordMonadIDs(sampling::Sampling) = recordMonadIDs(sampling.id, sampling.monad_ids)
 
 function recordSamplingIDs(trial_id::Int, sampling_ids::Array{Int})
-    recordSamplingIDs(joinpath(data_dir, "outputs", "trials", string(trial_id)), sampling_ids)
+    recordSamplingIDs(outputFolder("trial", trial_id), sampling_ids)
 end
 
 function recordSamplingIDs(trial::Trial)
-    recordSamplingIDs(joinpath(data_dir, "outputs", "trials", string(trial.id)), trial.sampling_ids)
+    recordSamplingIDs(outputFolder(trial), trial.sampling_ids)
 end
 
 function recordSamplingIDs(path_to_folder::String, sampling_ids::Array{Int})

--- a/src/VCTSensitivity.jl
+++ b/src/VCTSensitivity.jl
@@ -365,7 +365,7 @@ end
 
 function recordSensitivityScheme(gsa_sampling::GSASampling)
     method = methodString(gsa_sampling)
-    path_to_csv = joinpath(getOutputFolder(gsa_sampling.sampling), "$(method)_scheme.csv")
+    path_to_csv = joinpath(outputFolder(gsa_sampling.sampling), "$(method)_scheme.csv")
     return CSV.write(path_to_csv, getMonadIDDataFrame(gsa_sampling); header=true)
 end
 

--- a/src/VCTVariations.jl
+++ b/src/VCTVariations.jl
@@ -8,25 +8,25 @@ export GridVariation, LHSVariation, addVariations
 
 abstract type AbstractVariation end
 struct ElementaryVariation{T} <: AbstractVariation
-    xml_path::Vector{String}
+    xml_path::Vector{<:AbstractString}
     values::Vector{T}
 end
 
-ElementaryVariation(xml_path::Vector{String}, value::T) where T = ElementaryVariation{T}(xml_path, [value])
+ElementaryVariation(xml_path::Vector{<:AbstractString}, value::T) where T = ElementaryVariation{T}(xml_path, [value])
 
 struct DistributedVariation <: AbstractVariation
-    xml_path::Vector{String}
+    xml_path::Vector{<:AbstractString}
     distribution::Distribution
 end
 
-xmlPath(av::AbstractVariation) = av.xml_path::Vector{String}
+xmlPath(av::AbstractVariation) = av.xml_path::Vector{<:AbstractString}
 columnName(av::AbstractVariation) = xmlPath(av) |> xmlPathToColumnName
 
-function UniformDistributedVariation(xml_path::Vector{String}, lb::T, ub::T) where {T<:Real}
+function UniformDistributedVariation(xml_path::Vector{<:AbstractString}, lb::T, ub::T) where {T<:Real}
     return DistributedVariation(xml_path, Uniform(lb, ub))
 end
 
-function NormalDistributedVariation(xml_path::Vector{String}, mu::T, sigma::T; lb::Real=-Inf, ub::Real=Inf) where {T<:Real}
+function NormalDistributedVariation(xml_path::Vector{<:AbstractString}, mu::T, sigma::T; lb::Real=-Inf, ub::Real=Inf) where {T<:Real}
     return DistributedVariation(xml_path, truncated(Normal(mu, sigma), lb, ub))
 end
 


### PR DESCRIPTION
- CI now uses env var PCVCT_NUM_PARALLEL_SIMS (instead of JULIA_NUM_THREADS) to control how many sims to run in parallel
- docs for VCTDatabase.jl and VCTHPC.jl
- use `outputFolder` to get path to `data/outputs/<types>/id
- allow for Trial to read in AbstractString for folders, not only String in some instances (point to update next)
- VCTCompilation.jl
  - simplify documentation
  - return bool indicating success of loadCustomCode
  - compile in separate folder to make sure two processes do not interfere with compilation
    - put the new PhysiCell in the AbstractSampling folder
    - add a randomstring of 10 characters to the folder name
    - delete the temp folder when finished compiling (after moving the executable to the inputs/custom_codes/folder folder)
  - try-catch block for compilation errors so the rest of the code can run
  - if compilation.err is not empty but did not error (likely due to warnings), print a warning
  - allow user to set `march` flag. autoset to "native" for local runs and "x86-64" for hpc runs
  - simplify check for if executable exists
- all `xml_paths` are now `Vector{<:AbstractString}` instead of `Vector{String}` to be more robust
- docstring for `isStarted`
- VCTHPC.jl
  - checks if running on HPC (sees if `sbatch` is a command in the shell)
  - sets `run_on_hpc` according to this check
  - allows user to set this boolean flag (`useHPC`)
  - defines default sbatch options
  - allow users to overwrite the job options
- VCTRunner.jl
  - refactor runSimulation into simulationProcess -> prepareSimulationCommand -> simulationProcess
    - the output of this is then wrapped in a task in calls to runAbstractTrial
    - if loading custom code and it fails, return gracefully
    - write `sbatch` call if running on hpc
      - importantly, include `--wait` flag to make sure we wait for the job to finish before moving on
    - if compilation of monad/sampling fail, return gracefully
    - channels to handle parallelization locally on hpc
      - `queue_channel` to queue the simulations to be picked up as tasks are available
      - `result_channel` to store the results of the simulations as they finish - async put all the simulations in the queue - start `num_parallel_sims` tasks to pick up the simulations from the queue and put them in the results channel when done
        - this is the total number of simulations if on the hpc; otherwise, it is the env var `PCVCT_NUM_PARALLEL_SIMS` or 1 (if it's not set) - ensure all sims finish by looping (not `@async`-ed) over the number of simulation_tasks, `take!`-ing from the result channel

To-do
- update VCTClasses.jl to have everything accept `Integer` and `AbstractString` instead of `Int` and `String`
- make sure the quoting of sbatch flags if they have spaces actually works