### PR TITLE
createTrial and run to simplify API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "pcvct"
 uuid = "3c374bc7-7384-4f83-8ca0-87b8c727e6ff"
 authors = ["Daniel Bergman <danielrbergman@gmail.com> and contributors"]
-version = "0.0.12"
+version = "0.0.13"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/VCTConfiguration.jl
+++ b/src/VCTConfiguration.jl
@@ -106,12 +106,12 @@ function loadConfiguration(sampling::Sampling)
 end
 
 function loadRulesets(M::AbstractMonad)
-    if M.variation_ids.rulesets == -1 # no rules being used
+    if M.variation_ids.rulesets_collection == -1 # no rules being used
         return
     end
     path_to_rulesets_collections_folder = joinpath(data_dir, "inputs", "rulesets_collections", M.inputs.rulesets_collection.folder)
-    path_to_rulesets_xml = joinpath(path_to_rulesets_collections_folder, "rulesets_collections_variations", "rulesets_variation_$(M.variation_ids.rulesets).xml")
-    if isfile(path_to_rulesets_xml) # already have the rulesets variation created
+    path_to_rulesets_xml = joinpath(path_to_rulesets_collections_folder, "rulesets_collections_variations", "rulesets_variation_$(M.variation_ids.rulesets_collection).xml")
+    if isfile(path_to_rulesets_xml) # already have the rulesets_collection variation created
         return
     end
     mkpath(dirname(path_to_rulesets_xml)) # ensure the directory exists
@@ -124,11 +124,11 @@ function loadRulesets(M::AbstractMonad)
     end
         
     xml_doc = parse_file(path_to_base_xml)
-    if M.variation_ids.rulesets != 0 # only update if not using the base variation for the ruleset
-        query = constructSelectQuery("rulesets_variations", "WHERE rulesets_variation_id=$(M.variation_ids.rulesets);")
+    if M.variation_ids.rulesets_collection != 0 # only update if not using the base variation for the ruleset
+        query = constructSelectQuery("rulesets_collection_variations", "WHERE rulesets_collection_variation_id=$(M.variation_ids.rulesets_collection);")
         variation_row = queryToDataFrame(query; db=rulesetsCollectionDB(M), is_row=true)
         for column_name in names(variation_row)
-            if column_name == "rulesets_variation_id"
+            if column_name == "rulesets_collection_variation_id"
                 continue
             end
             xml_path = columnNameToXMLPath(column_name)
@@ -291,7 +291,7 @@ function simpleConfigVariationNames(name::String)
 end
 
 function simpleRulesetsVariationNames(name::String)
-    if name == "rulesets_variation_id"
+    if name == "rulesets_collection_variation_id"
         return "RulesVarID"
     elseif startswith(name, "hypothesis_ruleset")
         return getRuleParameterName(name)

--- a/src/VCTDeletion.jl
+++ b/src/VCTDeletion.jl
@@ -21,11 +21,11 @@ function deleteSimulations(simulation_ids::AbstractVector{<:Integer}; delete_sup
         rulesets_collection_folder = rulesetsCollectionFolder(row.rulesets_collection_id)
         result_df = constructSelectQuery(
             "simulations",
-            "WHERE rulesets_collection_id = $(row.rulesets_collection_id) AND rulesets_variation_id = $(row.rulesets_variation_id);";
+            "WHERE rulesets_collection_id = $(row.rulesets_collection_id) AND rulesets_collection_variation_id = $(row.rulesets_collection_variation_id);";
             selection="COUNT(*)"
         ) |> queryToDataFrame
         if result_df.var"COUNT(*)"[1] == 0
-            rm(joinpath(data_dir, "inputs", "rulesets_collections", rulesets_collection_folder, "rulesets_collections_variations", "rulesets_variation_$(row.rulesets_variation_id).xml"); force=true)
+            rm(joinpath(data_dir, "inputs", "rulesets_collections", rulesets_collection_folder, "rulesets_collections_variations", "rulesets_variation_$(row.rulesets_collection_variation_id).xml"); force=true)
         end
 
         ic_cell_folder = icCellFolder(row.ic_cell_id)
@@ -263,7 +263,7 @@ function resetRulesetsCollectionFolder(path_to_rulesets_collection_folder::Strin
     if !isdir(path_to_rulesets_collection_folder)
         return
     end
-    rm(joinpath(path_to_rulesets_collection_folder, "rulesets_variations.db"); force=true)
+    rm(joinpath(path_to_rulesets_collection_folder, "rulesets_collection_variations.db"); force=true)
     rm(joinpath(path_to_rulesets_collection_folder, "rulesets_collections_variations"); force=true, recursive=true)
 end
 
@@ -326,7 +326,7 @@ function eraseSimulationID(simulation_id::Int; monad_id::Union{Missing,Int}=miss
     if ismissing(monad_id)
         query = constructSelectQuery("simulations", "WHERE simulation_id = $(simulation_id);")
         df = queryToDataFrame(query)
-        query = constructSelectQuery("monads", "WHERE (config_id, config_variation_id, rulesets_collection_id, rulesets_variation_id, ic_cell_id, ic_cell_variation_id) = ($(df.config_id[1]), $(df.config_variation_id[1]), $(df.rulesets_collection_id[1]), $(df.rulesets_variation_id[1]), $(df.ic_cell_id[1]), $(df.ic_cell_variation_id[1]));"; selection="monad_id")
+        query = constructSelectQuery("monads", "WHERE (config_id, config_variation_id, rulesets_collection_id, rulesets_collection_variation_id, ic_cell_id, ic_cell_variation_id) = ($(df.config_id[1]), $(df.config_variation_id[1]), $(df.rulesets_collection_id[1]), $(df.rulesets_collection_variation_id[1]), $(df.ic_cell_id[1]), $(df.ic_cell_variation_id[1]));"; selection="monad_id")
         df = queryToDataFrame(query)
         monad_id = df.monad_id[1]
     end

--- a/src/VCTExport.jl
+++ b/src/VCTExport.jl
@@ -67,7 +67,7 @@ function prepareFolder(simulation::Simulation, export_folder::AbstractString)
     # rulesets
     if row.rulesets_collection_id[1] != -1
         rulesets_collection_folder = simulation.inputs.rulesets_collection.folder
-        path_to_xml = joinpath(data_dir, "inputs", "rulesets_collections", rulesets_collection_folder, "rulesets_collections_variations", "rulesets_variation_$(row.rulesets_variation_id[1]).xml")
+        path_to_xml = joinpath(data_dir, "inputs", "rulesets_collections", rulesets_collection_folder, "rulesets_collections_variations", "rulesets_variation_$(row.rulesets_collection_variation_id[1]).xml")
         path_to_csv = joinpath(export_folder, "config", "cell_rules.csv")
         exportRulesToCSV(path_to_csv, path_to_xml)
     end

--- a/src/VCTImport.jl
+++ b/src/VCTImport.jl
@@ -25,7 +25,7 @@ struct ImportSources
     main::ImportSource
     makefile::ImportSource
     custom_modules::ImportSource
-    rules::ImportSource
+    rulesets_collection::ImportSource
     ic_cell::ImportSource
     ic_substrate::ImportSource
     ic_ecm::ImportSource

--- a/src/VCTModule.jl
+++ b/src/VCTModule.jl
@@ -21,6 +21,8 @@ include("VCTVersion.jl")
 include("VCTPhysiCellVersion.jl")
 include("VCTHPC.jl")
 
+include("VCTUserAPI.jl")
+
 include("VCTLoader.jl")
 
 include("VCTAnalysis.jl")

--- a/src/VCTUserAPI.jl
+++ b/src/VCTUserAPI.jl
@@ -1,0 +1,50 @@
+import Base.run
+
+export createTrial
+
+function createTrial(inputs::InputFolders, evs::Vector{<:ElementaryVariation}=ElementaryVariation[]; n_replicates::Integer=1,
+                     use_previous::Bool=true)
+    return _createTrial(inputs, VariationIDs(inputs), evs, n_replicates, use_previous)
+end
+
+function createTrial(inputs::InputFolders, ev::ElementaryVariation; n_replicates::Integer=1, use_previous::Bool=true)
+    return _createTrial(inputs, VariationIDs(inputs), [ev], n_replicates, use_previous)
+end
+
+function createTrial(reference::AbstractMonad, evs::Vector{<:ElementaryVariation}=ElementaryVariation[]; n_replicates::Integer=1,
+    use_previous::Bool=true)
+    return _createTrial(reference.inputs, reference.variation_ids, evs, n_replicates, use_previous)
+end
+
+function createTrial(reference::AbstractMonad, ev::ElementaryVariation; n_replicates::Integer=1, use_previous::Bool=true)
+    return _createTrial(reference.inputs, reference.variation_ids, [ev], n_replicates, use_previous)
+end
+
+function _createTrial(inputs::InputFolders, reference_variation_ids::VariationIDs, evs::Vector{<:ElementaryVariation}, n_replicates::Integer, use_previous::Bool)
+    config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(GridVariation(), inputs, evs, reference_variation_ids)
+    if length(config_variation_ids) == 1
+        variation_ids = VariationIDs(config_variation_ids[1], rulesets_collection_variation_ids[1], ic_cell_variation_ids[1])
+        monad = Monad(n_replicates, inputs, variation_ids; use_previous=use_previous)
+        if n_replicates != 1
+            return monad
+        end
+        return Simulation(monad.simulation_ids[end])
+    else
+        return Sampling(inputs; n_replicates=n_replicates,
+                        config_variation_ids=config_variation_ids,
+                        rulesets_collection_variation_ids=rulesets_collection_variation_ids,
+                        ic_cell_variation_ids=ic_cell_variation_ids,
+                        use_previous=use_previous)
+    end
+end
+
+function run(inputs::InputFolders, args...; force_recompile::Bool=false, prune_options::PruneOptions=PruneOptions(), kwargs...)
+    trial = createTrial(inputs, args...; kwargs...)
+    return run(trial; force_recompile=force_recompile, prune_options=prune_options)
+end
+
+function run(reference::AbstractMonad, evs::Union{ElementaryVariation,Vector{<:ElementaryVariation}}; n_replicates::Integer=1,
+             use_previous::Bool=true, force_recompile::Bool=false, prune_options::PruneOptions=PruneOptions())
+    trial = createTrial(reference, evs; n_replicates=n_replicates, use_previous=use_previous)
+    return run(trial; force_recompile=force_recompile, prune_options=prune_options)
+end

--- a/test/test-project/VCT/ClassesTests.jl
+++ b/test/test-project/VCT/ClassesTests.jl
@@ -18,14 +18,14 @@ simulation = Simulation(1)
 monad = Monad(1)
 @test monad isa Monad
 
-monad_min_length = 1
+n_replicates = 1
 config_variation_ids = [1, 2]
-rulesets_variation_ids = [1, 1]
+rulesets_collection_variation_ids = [1, 1]
 ic_cell_variation_ids = [0, 0]
 sampling = Sampling(inputs;
-    monad_min_length=monad_min_length,
+    n_replicates=n_replicates,
     config_variation_ids=config_variation_ids,
-    rulesets_variation_ids=rulesets_variation_ids,
+    rulesets_collection_variation_ids=rulesets_collection_variation_ids,
     ic_cell_variation_ids=ic_cell_variation_ids
 )
 @test sampling isa Sampling

--- a/test/test-project/VCT/ICCellTests.jl
+++ b/test/test-project/VCT/ICCellTests.jl
@@ -10,7 +10,7 @@ rulesets_collection_folder = "0_template"
 ic_cell_folder = "1_xml"
 inputs = InputFolders(config_folder, custom_code_folder; rulesets_collection=rulesets_collection_folder, ic_cell=ic_cell_folder)
 
-monad_min_length = 1
+n_replicates = 1
 
 discrete_variations = DiscreteVariation[]
 push!(discrete_variations, DiscreteVariation(["overall","max_time"], 12.0))
@@ -21,21 +21,16 @@ xml_path = ["cell_patches:name:default", "patch_collection:type:disc", "patch:ID
 vals = [0.0, -100.0]
 push!(discrete_variations, DiscreteVariation(xml_path, vals))
 
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = addVariations(GridVariation(), inputs, discrete_variations)
+sampling = createTrial(inputs, discrete_variations; n_replicates=n_replicates)
+
+@test sampling isa Sampling
 
 hashBorderPrint("SUCCESSFULLY ADDED IC CELL VARIATION!")
 
-sampling = Sampling(inputs;
-    monad_min_length=monad_min_length,
-    config_variation_ids=config_variation_ids,
-    rulesets_variation_ids=rulesets_variation_ids,
-    ic_cell_variation_ids=ic_cell_variation_ids
-)
-
 hashBorderPrint("SUCCESSFULLY CREATED SAMPLING WITH IC CELL VARIATION!")
 
-n_success = run(sampling; force_recompile=false)
-@test n_success == length(sampling)
+out = run(sampling; force_recompile=false)
+@test out.n_success == length(sampling)
 
 simulation_with_ic_cell_xml_id = getSimulationIDs(sampling)[1] # used in ExportTests.jl
 
@@ -45,16 +40,7 @@ discrete_variations = DiscreteVariation[]
 xml_path = ["cell_patches:name:default", "patch_collection:type:annulus", "patch:ID:1", "inner_radius"]
 push!(discrete_variations, DiscreteVariation(xml_path, 300.0))
 
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = 
-    addVariations(GridVariation(), inputs, discrete_variations;
-    reference_config_variation_id=config_variation_ids[1], reference_rulesets_variation_id=rulesets_variation_ids[1], reference_ic_cell_variation_id=ic_cell_variation_ids[1])
-
-sampling = Sampling(inputs;
-    monad_min_length=monad_min_length,
-    config_variation_ids=config_variation_ids,
-    rulesets_variation_ids=rulesets_variation_ids,
-    ic_cell_variation_ids=ic_cell_variation_ids
-)
+sampling = createTrial(Monad(sampling.monad_ids[1]), discrete_variations; n_replicates=n_replicates)
     
-n_success = run(sampling; force_recompile=false)
-@test n_success == 0
+out = run(sampling; force_recompile=false)
+@test out.n_success == 0

--- a/test/test-project/VCT/ImportTests.jl
+++ b/test/test-project/VCT/ImportTests.jl
@@ -23,18 +23,11 @@ push!(discrete_variations, DiscreteVariation(["overall","max_time"], [12.0]))
 push!(discrete_variations, DiscreteVariation(["save","full_data","interval"], [6.0]))
 push!(discrete_variations, DiscreteVariation(["save","SVG","interval"], [6.0]))
 
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = addVariations(GridVariation(), inputs, discrete_variations)
+sampling = createTrial(inputs, discrete_variations; n_replicates=1)
 
-sampling = Sampling(inputs;
-    monad_min_length=1,
-    config_variation_ids=config_variation_ids,
-    rulesets_variation_ids=rulesets_variation_ids,
-    ic_cell_variation_ids=ic_cell_variation_ids
-)
+out = run(sampling; force_recompile=false)
 
-n_success = run(sampling; force_recompile=false)
-
-@test n_success == length(sampling)
+@test out.n_success == length(sampling)
 
 success = importProject(path_to_project, src, dest)
 @test success

--- a/test/test-project/VCT/PrunerTests.jl
+++ b/test/test-project/VCT/PrunerTests.jl
@@ -7,8 +7,8 @@ simulation = Simulation(Monad(1))
 @test simulation isa Simulation
 
 prune_options = PruneOptions(true, true, true, true, true)
-n_success = run(simulation; force_recompile=false, prune_options=prune_options)
-@test n_success == 1
+out = run(simulation; force_recompile=false, prune_options=prune_options)
+@test out.n_success == 1
 
 pcvct.deleteSimulation(simulation.id)
 @test !isdir(joinpath(pcvct.data_dir, "outputs", "simulations", string(simulation.id)))

--- a/test/test-project/VCT/RunnerTests.jl
+++ b/test/test-project/VCT/RunnerTests.jl
@@ -11,24 +11,30 @@ custom_code_folder = "0_template"
 inputs = InputFolders(config_folder, custom_code_folder; rulesets_collection=rulesets_collection_folder)
 
 cell_type = "default"
-monad_min_length = 2
+n_replicates = 2
 
 discrete_variations = DiscreteVariation[]
 push!(discrete_variations, DiscreteVariation(["overall","max_time"], [12.0]))
 push!(discrete_variations, DiscreteVariation(["save","full_data","interval"], [6.0]))
 push!(discrete_variations, DiscreteVariation(["save","SVG","interval"], [6.0]))
 
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = addVariations(GridVariation(), inputs, discrete_variations)
-hashBorderPrint("DATABASE SUCCESSFULLY UPDATED!")
+simulation = createTrial(inputs, discrete_variations)
 
-config_variation_id = config_variation_ids[1]
-rulesets_variation_id = rulesets_variation_ids[1]
-ic_cell_variation_id = ic_cell_variation_ids[1]
-variation_ids = pcvct.VariationIDs(config_variation_id, rulesets_variation_id, ic_cell_variation_id)
-simulation = Simulation(inputs, variation_ids)
+out = run(simulation)
+@test out.trial isa Simulation
+@test out.n_scheduled == 1
+@test out.n_success == 1
 
-n_success = run(simulation)
-if n_success == 0
+out2 = run(inputs, discrete_variations)
+@test out2.trial isa Simulation
+@test out2.n_scheduled == 0
+@test out2.n_success == 0
+
+@test out.trial.id == out2.trial.id 
+@test out.trial.inputs == out2.trial.inputs
+@test out.trial.variation_ids == out2.trial.variation_ids
+
+if out.n_success == 0
     hashBorderPrint("Simulation failed...")
     # print out the compilation error file if exists
     if isfile("$(path_to_data_folder)/inputs/custom_codes/$(custom_code_folder)/output.err")
@@ -49,7 +55,6 @@ if n_success == 0
         hashBorderPrint("No output log file found.")
     end
 end
-@test n_success == 1
 
 hashBorderPrint("SIMULATION SUCCESSFULLY RUN!")
 
@@ -68,23 +73,29 @@ push!(discrete_variations, DiscreteVariation(xml_path, [5.0, 6.0]))
 xml_path = [pcvct.cyclePath(cell_type); "phase_durations"; "duration:index:3"]
 push!(discrete_variations, DiscreteVariation(xml_path, [7.0, 8.0]))
 
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = addVariations(GridVariation(), inputs, discrete_variations; reference_config_variation_id=config_variation_id, reference_rulesets_variation_id=rulesets_variation_id, reference_ic_cell_variation_id=ic_cell_variation_id)
-sampling = Sampling(inputs;
-    monad_min_length=monad_min_length,
-    config_variation_ids=config_variation_ids,
-    rulesets_variation_ids=rulesets_variation_ids,
-    ic_cell_variation_ids=ic_cell_variation_ids
-)
+sampling = createTrial(simulation, discrete_variations; n_replicates=n_replicates)
 
 hashBorderPrint("SAMPLING SUCCESSFULLY CREATED!")
 
-n_success = run(sampling; force_recompile=false)
-@test n_success == length(sampling)
+out = run(sampling; force_recompile=false)
+@test out.n_success == length(sampling)
 
 hashBorderPrint("SAMPLING SUCCESSFULLY RUN!")
 
+out2 = run(simulation, discrete_variations; n_replicates=n_replicates, force_recompile=false)
+@test out2.trial isa Sampling
+@test out2.trial.id == sampling.id
+@test out2.trial.inputs == sampling.inputs
+@test Set(out2.trial.monad_ids) == Set(sampling.monad_ids)
+@test Set(pcvct.getSimulationIDs(out2.trial)) == Set(pcvct.getSimulationIDs(sampling))
+@test out2.n_scheduled == 0
+@test out2.n_success == 0
+
+hashBorderPrint("SUCCESSFULLY `run` WITHOUT CREATING SAMPLING!")
+
+
 n_simulations = length(sampling) # number of simulations recorded (in .csvs) for this sampling
-n_expected_sims = monad_min_length
+n_expected_sims = n_replicates
 for discrete_variation in discrete_variations
     global n_expected_sims *= length(discrete_variation)
 end
@@ -92,25 +103,25 @@ n_variations = length(sampling.variation_ids)
 
 # make sure the number of simulations in this sampling is what we expected based on...
 @test n_simulations == n_expected_sims # the discrete_variations...
-@test n_simulations == n_variations * monad_min_length # ...how many variation ids we recorded (number of rulesets_variations_ids must match variation_ids on construction of sampling)
-@test n_simulations == n_success # ...how many simulations succeeded
+@test n_simulations == n_variations * n_replicates # ...how many variation ids we recorded (number of rulesets_variations_ids must match variation_ids on construction of sampling)
+@test n_simulations == out.n_success # ...how many simulations succeeded
 
 hashBorderPrint("SAMPLING SUCCESSFULLY IN CSVS!")
 
-n_success = run(sampling; force_recompile=false)
+out = run(sampling; force_recompile=false)
 
 # no new simulations should have been run
-@test n_success == 0
+@test out.n_success == 0
 
 hashBorderPrint("SUCCESSFULLY FOUND PREVIOUS SIMS!")
 
 trial = Trial([sampling])
 @test trial isa Trial
 
-n_success = run(trial; force_recompile=false)
+out = run(trial; force_recompile=false)
 
 # no new simulations should have been run
-@test n_success == 0
+@test out.n_success == 0
 
 hashBorderPrint("SUCCESSFULLY RAN TRIAL!")
 

--- a/test/test-project/VCT/SensitivityTests.jl
+++ b/test/test-project/VCT/SensitivityTests.jl
@@ -40,14 +40,14 @@ ub = 1000.0
 push!(evs, NormalDistributedVariation(xml_path, mu, sigma; lb=lb, ub=ub))
 
 n_points = 2^3-1
-monad_min_length = 1
+n_replicates = 1
 
 gs_fn(simulation_id::Int) = finalPopulationCount(simulation_id)[cell_type]
 
-moat_sampling = run(MOAT(n_points), monad_min_length, inputs, evs; force_recompile=force_recompile, reference_config_variation_id=reference_config_variation_id, reference_rulesets_variation_id=reference_rulesets_variation_id, reference_ic_cell_variation_id=reference_ic_cell_variation_id, functions=[gs_fn])
-moat_sampling = run(MOAT(8; orthogonalize=true), monad_min_length, inputs, evs; force_recompile=force_recompile, reference_config_variation_id=reference_config_variation_id, reference_rulesets_variation_id=reference_rulesets_variation_id, reference_ic_cell_variation_id=reference_ic_cell_variation_id, functions=[gs_fn])
-sobol_sampling = run(Sobolʼ(n_points), monad_min_length, inputs, evs; force_recompile=force_recompile, reference_config_variation_id=reference_config_variation_id, reference_rulesets_variation_id=reference_rulesets_variation_id, reference_ic_cell_variation_id=reference_ic_cell_variation_id, functions=[gs_fn])
-rbd_sampling = run(RBD(n_points), monad_min_length, inputs, evs; force_recompile=force_recompile, reference_config_variation_id=reference_config_variation_id, reference_rulesets_variation_id=reference_rulesets_variation_id, reference_ic_cell_variation_id=reference_ic_cell_variation_id, functions=[gs_fn])
+moat_sampling = run(MOAT(n_points), n_replicates, inputs, evs; force_recompile=force_recompile, reference_config_variation_id=reference_config_variation_id, reference_rulesets_variation_id=reference_rulesets_variation_id, reference_ic_cell_variation_id=reference_ic_cell_variation_id, functions=[gs_fn])
+moat_sampling = run(MOAT(8; orthogonalize=true), n_replicates, inputs, evs; force_recompile=force_recompile, reference_config_variation_id=reference_config_variation_id, reference_rulesets_variation_id=reference_rulesets_variation_id, reference_ic_cell_variation_id=reference_ic_cell_variation_id, functions=[gs_fn])
+sobol_sampling = run(Sobolʼ(n_points), n_replicates, inputs, evs; force_recompile=force_recompile, reference_config_variation_id=reference_config_variation_id, reference_rulesets_variation_id=reference_rulesets_variation_id, reference_ic_cell_variation_id=reference_ic_cell_variation_id, functions=[gs_fn])
+rbd_sampling = run(RBD(n_points), n_replicates, inputs, evs; force_recompile=force_recompile, reference_config_variation_id=reference_config_variation_id, reference_rulesets_variation_id=reference_rulesets_variation_id, reference_ic_cell_variation_id=reference_ic_cell_variation_id, functions=[gs_fn])
 
 # test sensitivity with config, rules, and ic_cells at once
 ic_cell_folder = "1_xml"
@@ -75,6 +75,6 @@ push!(evs, UniformDistributedVariation(xml_path, 0.0, 1.0e-8))
 xml_path = ["cell_patches:name:default", "patch_collection:type:annulus", "patch:ID:1", "inner_radius"]
 push!(evs, UniformDistributedVariation(xml_path, 0.0, 1.0))
 
-moat_sampling = run(MOAT(n_points), monad_min_length, inputs, evs; force_recompile=force_recompile, reference_config_variation_id=reference_config_variation_id, reference_rulesets_variation_id=reference_rulesets_variation_id, reference_ic_cell_variation_id=reference_ic_cell_variation_id, functions=[gs_fn])
-n_simulations_expected = n_points * (length(evs) + 1) * monad_min_length
+moat_sampling = run(MOAT(n_points), n_replicates, inputs, evs; force_recompile=force_recompile, reference_config_variation_id=reference_config_variation_id, reference_rulesets_variation_id=reference_rulesets_variation_id, reference_ic_cell_variation_id=reference_ic_cell_variation_id, functions=[gs_fn])
+n_simulations_expected = n_points * (length(evs) + 1) * n_replicates
 @test length(moat_sampling.sampling) == n_simulations_expected

--- a/test/test-project/VCT/VariationsTests.jl
+++ b/test/test-project/VCT/VariationsTests.jl
@@ -28,51 +28,51 @@ vals = [1.0, 2.0]
 push!(discrete_variations, DiscreteVariation(xml_path, vals))
 
 # Test edge cases of addGrid
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = addVariations(GridVariation(), inputs, discrete_variations)
+config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(GridVariation(), inputs, discrete_variations)
 
 # Test edge cases of addLHS
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = addVariations(LHSVariation(4), inputs, discrete_variations)
+config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(LHSVariation(4), inputs, discrete_variations)
 
 discrete_variations = DiscreteVariation[]
 xml_path = [pcvct.cyclePath(cell_type); "phase_durations"; "duration:index:0"]
 push!(discrete_variations, DiscreteVariation(xml_path, [1.0, 2.0]))
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = addVariations(LHSVariation(4), inputs, discrete_variations)
+config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(LHSVariation(4), inputs, discrete_variations)
 
 discrete_variations = DiscreteVariation[]
 xml_path = ["cell_patches:name:default", "patch_collection:type:disc", "patch:ID:1", "x0"]
 vals = [0.0, -100.0]
 push!(discrete_variations, DiscreteVariation(xml_path, vals))
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = addVariations(LHSVariation(4), inputs, discrete_variations)
+config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(LHSVariation(4), inputs, discrete_variations)
 
 # Test edge cases of addSobol
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = addVariations(pcvct.SobolVariation(5), inputs, discrete_variations)
+config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(pcvct.SobolVariation(5), inputs, discrete_variations)
 
 discrete_variations = DiscreteVariation[]
 xml_path = [pcvct.cyclePath(cell_type); "phase_durations"; "duration:index:0"]
 push!(discrete_variations, DiscreteVariation(xml_path, [1.0, 2.0]))
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = addVariations(pcvct.SobolVariation(5; skip_start=false), inputs, discrete_variations)
+config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(pcvct.SobolVariation(5; skip_start=false), inputs, discrete_variations)
 
 discrete_variations = DiscreteVariation[]
 xml_path = ["hypothesis_ruleset:name:default","behavior:name:cycle entry","decreasing_signals","max_response"]
 vals = [1.0, 2.0]
 push!(discrete_variations, DiscreteVariation(xml_path, vals))
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = addVariations(pcvct.SobolVariation(5; skip_start=4, include_one=true), inputs, discrete_variations)
+config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(pcvct.SobolVariation(5; skip_start=4, include_one=true), inputs, discrete_variations)
 
 # Test edge cases of addRBD
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = addVariations(pcvct.RBDVariation(1), inputs, discrete_variations)
+config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(pcvct.RBDVariation(1), inputs, discrete_variations)
 
 discrete_variations = DiscreteVariation[]
 xml_path = ["cell_patches:name:default", "patch_collection:type:disc", "patch:ID:1", "x0"]
 vals = [0.0, -100.0]
 push!(discrete_variations, DiscreteVariation(xml_path, vals))
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = addVariations(pcvct.RBDVariation(2), inputs, discrete_variations)
+config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(pcvct.RBDVariation(2), inputs, discrete_variations)
 
 discrete_variations = DiscreteVariation[]
 xml_path = [pcvct.cyclePath(cell_type); "phase_durations"; "duration:index:0"]
 push!(discrete_variations, DiscreteVariation(xml_path, [1.0, 2.0]))
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = addVariations(pcvct.RBDVariation(3), inputs, discrete_variations)
+config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(pcvct.RBDVariation(3), inputs, discrete_variations)
 
-config_variation_ids, rulesets_variation_ids, ic_cell_variation_ids = addVariations(pcvct.RBDVariation(3; use_sobol=false), inputs, discrete_variations)
+config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(pcvct.RBDVariation(3; use_sobol=false), inputs, discrete_variations)
 
 # test deprecation of ElementaryVariation
 @test_warn "`ElementaryVariation` is deprecated in favor of the more descriptive `DiscreteVariation`." ElementaryVariation(xml_path, [0.0, 1.0])


### PR DESCRIPTION
- standardizing rulesets_collection
- VariationIDs.rulesets_collection
- min_length->n_replicates
- createTrial
- also use_previous_simulations -> use_previous
- rulesets_variation_ids -> rulesets_collection_variation_ids
- `run` with same args as `createTrial`
- create `PCVCTOutput` to hold trial, n scheduled, and n success
- force_recompile set to false throughout