### PR TITLE
CoVariations

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,6 +16,7 @@ makedocs(;
         "Manual" => Any[
             "Best practices" => "man/best_practices.md",
             "Getting started" => "man/getting_started.md",
+            "CoVariations" => "man/covariations.md",
             "Data directory" => "man/data_directory.md",
             "Known limitations" => "man/known_limitations.md",
             "PhysiCell Studio" => "man/physicell_studio.md",

--- a/docs/src/man/covariations.md
+++ b/docs/src/man/covariations.md
@@ -1,0 +1,65 @@
+# CoVariations
+Sometimes several parameters need to be varied together.
+A common use case is the varying the base value of a rule and the max response of the rule[^1]
+To handle this scenario, pcvct provides the `CoVariation` type.
+A `CoVariation` is a wrapper for a vector of `ElementaryVariation`'s, and each `ElementaryVariation` must be of the same type, i.e., all `DiscreteVariation`'s or all `DistributedVariation`'s.
+The type of a `CoVariation` is parameterized by the type of `ElementaryVariation`'s it contains.
+Thus, there are, for now, two types of `CoVariation`'s: `CoVariation{DiscreteVariation}` and `CoVariation{DistributedVariation}`.
+
+[^1]: PhysiCell does not allow the base value to exceed the max response. That is, the base response of a decreasing signal cannot be < the max response. Similarly, the base resposne of an increasing signal cannot be > the max response.
+
+## `CoVariation{DiscreteVariation}`
+For a `CoVariation{DiscreteVariation}`, each of the `DiscreteVariation`'s must have the same number of values.
+This may be relaxed in future versions, but the primary use case anticipated is a [`GridVariation`](@ref) which requires the variations to inform the size of the grid.
+No restrictions are imposed on how the values of the various variations are linked.
+pcvct will use values that share an index their respective vectors together.
+
+```julia
+base_xml_path = pcvct.customDataPath("default", "sample")
+ev1 = DiscreteVariation(base_xml_path, [1, 2, 3]) # vary the `sample` custom data for cell type default
+max_xml_path = ["hypothesis_ruleset:name:default", "behavior:name:custom sample", "increasing_signals", "max_response"] # the max response of the rule increasing sample (must be bigger than the base response above)
+ev2 = DiscreteVariation(rule_xml_path, [2, 3, 4])
+covariation = CoVariation(ev1, ev2) # CoVariation([ev1, ev2]) also works
+```
+
+It is also not necessary to create the `ElementaryVariation`'s separately and then pass them to the `CoVariation` constructor.
+```julia
+# have the phase durations vary by and compensate for each other
+phase_0_xml_path = [pcvct.cyclePath("default"); "phase_durations"; "duration:index:0"]
+phase_0_durations = [300.0, 400.0] 
+phase_1_durations = [200.0, 100.0] # the (mean) duration through these two phases is 500 min
+# input any number of tuples (xml_path, values)
+covariation = Covariation((phase_0_xml_path, phase_0_durations), (phase_1_xml_path, phase_1_durations))
+```
+
+## `CoVariation{DistributedVariation}`
+For a `CoVariation{DistributedVariation}`, the conversion of a CDF value, $x \in [0, 1]$, is done independently for each distribution.
+That is, in the joint probability space, a `CoVariation{DistributedVariation}` restricts us to the one-dimensional line connecting $\mathbf{0}$ to $\mathbf{1}$.
+To allow for the parameters to vary inversely with one another, the `DistributedVariation` type accepts an optional `flip::Bool` argument (not a keyword argument!).
+For a distribution `dv` with `dv.flip=true`, when a value is requested with a CDF $x$, pcvct will "flip" the CDF to give the value with CDF $1 - x$.
+
+```jldoctest
+using pcvct
+timing_1_path = pcvct.userParameterPath("event_1_time")
+timing_2_path = pcvct.userParameterPath("event_2_time")
+dv1 = UniformDistributedVariation(timing_1_path, 100.0, 200.0)
+flip = true
+dv2 = UniformDistributedVariation(timing_2_path, 100.0, 200.0, flip)
+covariation = CoVariation(dv1, dv2)
+cdf = 0.1
+pcvct._values.(covariation.variations, cdf) # pcvct internal for getting values for an ElementaryVariation
+# output
+2-element Vector{Vector{Float64}}:
+ [110.0]
+ [190.0]
+```
+
+As with `CoVariation{DiscreteVariation}`, it is not necessary to create the `ElementaryVariation`'s separately and then pass them to the `CoVariation` constructor. It is not possible to `flip` a `DistributedVariation` with this syntax, however.
+
+```julia
+apop_xml_path = [pcvct.apoptosisPath("default"); "death_rate"]
+apop_dist = Uniform(0, 0.001)
+cycle_entry_path = [pcvct.cyclePath("default"); "phase_transition_rates"; "rate:start_index:0"]
+cycle_dist = Uniform(0.00001, 0.0001)
+covariation = CoVariation((apop_xml_path, apop_dist), (cycle_entry_path, cycle_dist))
+```

--- a/docs/src/man/sensitivity_analysis.md
+++ b/docs/src/man/sensitivity_analysis.md
@@ -120,3 +120,29 @@ evs = [NormalDistributedVariation([pcvct.apoptosisPath("cancer"); "rate"], 1e-3,
 method = MOAT(15)
 sensitivity_sampling = run(method, inputs, n_replicates, evs)
 ```
+
+## Post-processing
+The object `sensitivity_sampling` is of type [`pcvct.GSASampling`](@ref), meaning you can use [`pcvct.calculateGSA!`](@ref) to compute sensitivity analyses.
+```julia
+f = simulation_id -> finalPopulationCount(simulation_id)["default"] # count the final population of cell type "default"
+calculateGSA!(sensitivity_sampling, f)
+```
+These results are stored in a `Dict` in the `sensitivity_sampling` object:
+```julia
+println(sensitivity_sampling.results[f])
+```
+
+The exact concrete type of `sensitivity_sampling` will depend on the `method` used.
+This, in turn, is used by `calculateGSA!` to determine how to compute the sensitivity indices.
+
+Likewise, the `method` will determine how the sensitivity scheme is saved
+After running the simulations, pcvct will print a CSV in the `data/outputs/sampling/$(sampling)` folder named based on the `method`.
+This can later be used to reload the `GSASampling` and continue doing analysis.
+Currently, this requires some ingenuity by the user.
+A future version of pcvct could provide convenience functions for simplifying this.
+```julia
+using CSV, DataFrames
+sampling_id = 1 # for example
+monad_ids_df = CSV.read("data/outputs/samplings/$(sampling_id)/moat_scheme.csv", DataFrame) # if this was a MOAT scheme
+moat_sampling = MOATSampling(Sampling(sampling_id), monad_ids_df, Dict{Function, GlobalSensitivity.MorrisResult}())
+```

--- a/src/VCTConfiguration.jl
+++ b/src/VCTConfiguration.jl
@@ -345,8 +345,18 @@ function getCellParameterName(column_name::String)
     cell_type = split(xml_path[2], ":")[3]
     target_name = ""
     for component in xml_path[3:end]
-        if occursin(":name:", component)
+        if contains(component, ":name:")
             target_name = split(component, ":")[3]
+            break
+        elseif contains(component, ":code:")
+            target_code = split(component, ":")[3]
+            if target_code == "100"
+                target_name = "apop"
+            elseif target_code == "101"
+                target_name = "necr"
+            else
+                throw(ArgumentError("Unknown code in xml path: $(target_code)"))
+            end
             break
         end
     end

--- a/src/VCTCreation.jl
+++ b/src/VCTCreation.jl
@@ -137,7 +137,7 @@ function setUpTemplate(physicell_dir::String, inputs_dir::String)
     setUpICFolder(path_to_template, inputs_dir, "substrates", "0_template")
 
     # also set up a ic cell folder using the xml-based version
-    createICCellXMLTemplate("1_xml")
+    createICCellXMLTemplate(joinpath(inputs_dir, "ics", "cells", "1_xml"))
 end
 
 function setUpVCT(project_dir::String, physicell_dir::String, data_dir::String, template_as_default::Bool, terse::Bool)

--- a/src/VCTICCell.jl
+++ b/src/VCTICCell.jl
@@ -120,7 +120,11 @@ These will all be stored with `data/inputs/ics/cells/folder/ic_cell_variations` 
 Importantly, no two simulations will use the same CSV file.
 """
 function createICCellXMLTemplate(folder::String)
-    path_to_ic_cell_xml = joinpath(data_dir, "inputs", "ics", "cells", folder, "cells.xml")
+    if length(splitpath(folder)) == 1
+        # then the folder is just the name of the ics/cells/folder folder
+        folder = joinpath(data_dir, "inputs", "ics", "cells", folder)
+    end
+    path_to_ic_cell_xml = joinpath(folder, "cells.xml")
     mkpath(dirname(path_to_ic_cell_xml))
     xml_doc = XMLDocument()
     xml_root = create_root(xml_doc, "ic_cells")
@@ -146,4 +150,5 @@ function createICCellXMLTemplate(folder::String)
         set_content(e, value)
     end
     save_file(xml_doc, path_to_ic_cell_xml)
+    closeXML(xml_doc)
 end

--- a/src/VCTModule.jl
+++ b/src/VCTModule.jl
@@ -1,4 +1,4 @@
-using SQLite, DataFrames, LightXML, LazyGrids, Dates, CSV, Tables, Distributions, Statistics, Random, QuasiMonteCarlo, Sobol
+using SQLite, DataFrames, LightXML, Dates, CSV, Tables, Distributions, Statistics, Random, QuasiMonteCarlo, Sobol
 using PhysiCellXMLRules
 
 export initializeVCT, getSimulationIDs, setNumberOfParallelSims

--- a/src/VCTRunner.jl
+++ b/src/VCTRunner.jl
@@ -205,6 +205,8 @@ struct PCVCTOutput
     n_success::Int
 end
 
+getSimulationIDs(output::PCVCTOutput) = getSimulationIDs(output.trial)
+
 """
     run(T::AbstractTrial[; force_recompile::Bool=false, prune_options::PruneOptions=PruneOptions()])`
 

--- a/src/VCTSensitivity.jl
+++ b/src/VCTSensitivity.jl
@@ -4,6 +4,25 @@ import GlobalSensitivity # do not bring in their definition of Sobol as it confl
 export MOAT, Sobolʼ, RBD
 
 abstract type GSAMethod end
+
+"""
+    GSASampling
+
+Store the information that comes out of a global sensitivity analysis method.
+
+# Subtypes
+- [`MOATSampling`](@ref)
+- [`SobolSampling`](@ref)
+- [`RBDSampling`](@ref)
+
+# Methods
+- `getMonadIDDataFrame(gsa_sampling::GSASampling)`: get the DataFrame of monad IDs that define the scheme of the sensitivity analysis.
+- `getSimulationIDs(gsa_sampling::GSASampling)`: get the simulation IDs that were run in the sensitivity analysis.
+- `methodString(gsa_sampling::GSASampling)`: get the string representation of the method used in the sensitivity analysis.
+- `sensitivityResults!(gsa_sampling::GSASampling, functions::Vector{<:Function})`: calculate the sensitivity indices for the given functions.
+- `calculateGSA!(gsa_sampling::GSASampling, f::Vector{<:Function})`: calculate the sensitivity indices for the given function(s).
+- `evaluateFunctionOnSampling(gsa_sampling::GSASampling, f::Function)`: evaluate the function on the sampling and return the results.
+"""
 abstract type GSASampling end
 
 getMonadIDDataFrame(gsa_sampling::GSASampling) = gsa_sampling.monad_ids_df
@@ -24,7 +43,7 @@ Run a global sensitivity analysis method on the given arguments.
 - `method::GSAMethod`: the method to run. Options are [`MOAT`](@ref), [`Sobolʼ`](@ref), and [`RBD`](@ref).
 - `n_replicates::Int`: the number of replicates to run for each monad, i.e., at each sampled parameter vector.
 - `inputs::InputFolders`: the input folders shared across all simuations to run.
-- `evs::Vector{<:ElementaryVariation}`: the elementary variations to sample. These can be either [`DiscreteVariation`](@ref)'s or [`DistributedVariation`](@ref)'s.
+- `avs::Vector{<:AbstractVariation}`: the elementary variations to sample. These can be either [`DiscreteVariation`](@ref)'s or [`DistributedVariation`](@ref)'s.
 
 Alternatively, the third argument, `inputs`, can be replaced with a `reference::AbstractMonad`, i.e., a simulation or monad to be the reference.
 This should be preferred to setting reference variation IDs manually, i.e., if not using the base files in the input folders.
@@ -34,23 +53,24 @@ The three `reference_` keyword arguments are only compatible when the third argu
 - `reference_config_variation_id::Int=0`: the reference config variation ID
 - `reference_rulesets_variation_id::Int=0`: the reference rulesets variation ID
 - `reference_ic_cell_variation_id::Int=0`: the reference IC cell variation ID
-- `ignore_indices::Vector{Int}=[]`: indices into `evs` to ignore when perturbing the parameters. Only used for Sobolʼ. See [`Sobolʼ`](@ref) for a use case.
+- `ignore_indices::Vector{Int}=[]`: indices into `avs` to ignore when perturbing the parameters. Only used for Sobolʼ. See [`Sobolʼ`](@ref) for a use case.
 - `force_recompile::Bool=false`: whether to force recompilation of the simulation code
 - `prune_options::PruneOptions=PruneOptions()`: the options for pruning the simulation results
 - `use_previous::Bool=true`: whether to use previous simulation results if they exist
 - `functions::Vector{<:Function}=Function[]`: the functions to calculate the sensitivity indices for. Each function must take a simulation ID as the singular input and return a real number.
 """
-function run(method::GSAMethod, n_replicates::Integer, inputs::InputFolders, evs::Union{ElementaryVariation,Vector{<:ElementaryVariation}}; functions::Vector{<:Function}=Function[], kwargs...)
-    if evs isa ElementaryVariation
-        evs = [evs]
+function run(method::GSAMethod, n_replicates::Integer, inputs::InputFolders, avs::Union{AbstractVariation,Vector{<:AbstractVariation}}; functions::Vector{<:Function}=Function[], kwargs...)
+    if avs isa AbstractVariation
+        avs = [avs]
     end
-    gsa_sampling = _runSensitivitySampling(method, n_replicates, inputs, evs; kwargs...)
+    pv = ParsedVariations(avs)
+    gsa_sampling = _runSensitivitySampling(method, n_replicates, inputs, pv; kwargs...)
     sensitivityResults!(gsa_sampling, functions)
     return gsa_sampling
 end
 
-function run(method::GSAMethod, n_replicates::Integer, reference::AbstractMonad, evs::Union{ElementaryVariation,Vector{<:ElementaryVariation}}; functions::Vector{<:Function}=Function[], kwargs...)
-    return run(method, n_replicates, reference.inputs, evs;
+function run(method::GSAMethod, n_replicates::Integer, reference::AbstractMonad, avs::Union{AbstractVariation,Vector{<:AbstractVariation}}; functions::Vector{<:Function}=Function[], kwargs...)
+    return run(method, n_replicates, reference.inputs, avs;
                reference_config_variation_id=reference.variation_ids.config,
                reference_rulesets_variation_id=reference.variation_ids.rulesets_collection,
                reference_ic_cell_variation_id=reference.variation_ids.ic_cell,
@@ -60,6 +80,27 @@ end
 function sensitivityResults!(gsa_sampling::GSASampling, functions::Vector{<:Function})
     calculateGSA!(gsa_sampling, functions)
     recordSensitivityScheme(gsa_sampling)
+end
+
+"""
+    calculateGSA!(gsa_sampling::GSASampling, functions::Vector{<:Function})
+
+Calculate the sensitivity indices for the given functions.
+
+This function is also used to compute the sensitivity indices for a single function:
+```julia
+calculateGSA!(gsa_sampling, f)
+```
+
+# Arguments
+- `gsa_sampling::GSASampling`: the sensitivity analysis to calculate the indices for.
+- `functions::Vector{<:Function}`: the functions to calculate the sensitivity indices for. Each function must take a simulation ID as the singular input and return a real number.
+"""
+function calculateGSA!(gsa_sampling::GSASampling, functions::Vector{<:Function})
+    for f in functions
+        calculateGSA!(gsa_sampling, f)
+    end
+    return
 end
 
 ############# Morris One-At-A-Time (MOAT) #############
@@ -87,6 +128,16 @@ end
 MOAT() = MOAT(LHSVariation(15)) # default to 15 points
 MOAT(n::Int; kwargs...) = MOAT(LHSVariation(n; kwargs...))
 
+"""
+    MOATSampling
+
+Store the information that comes out of a Morris One-At-A-Time (MOAT) global sensitivity analysis.
+
+# Fields
+- `sampling::Sampling`: the sampling used in the sensitivity analysis.
+- `monad_ids_df::DataFrame`: the DataFrame of monad IDs that define the scheme of the sensitivity analysis.
+- `results::Dict{Function, GlobalSensitivity.MorrisResult}`: the results of the sensitivity analysis for each function.
+"""
 struct MOATSampling <: GSASampling
     sampling::Sampling
     monad_ids_df::DataFrame
@@ -95,7 +146,7 @@ end
 
 MOATSampling(sampling::Sampling, monad_ids_df::DataFrame) = MOATSampling(sampling, monad_ids_df, Dict{Function, GlobalSensitivity.MorrisResult}())
 
-function _runSensitivitySampling(method::MOAT, n_replicates::Int, inputs::InputFolders, evs::Vector{<:ElementaryVariation};
+function _runSensitivitySampling(method::MOAT, n_replicates::Int, inputs::InputFolders, pv::ParsedVariations;
     reference_config_variation_id::Int=0, reference_rulesets_variation_id::Int=0,
     reference_ic_cell_variation_id::Int=inputs.ic_cell.folder=="" ? -1 : 0,
     ignore_indices::Vector{Int}=Int[], force_recompile::Bool=false, prune_options::PruneOptions=PruneOptions(), use_previous::Bool=true)
@@ -103,61 +154,61 @@ function _runSensitivitySampling(method::MOAT, n_replicates::Int, inputs::InputF
     if !isempty(ignore_indices)
         error("MOAT does not support ignoring indices...yet? Only Sobolʼ does for now.")
     end
-    config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(method.lhs_variation, inputs, evs; reference_config_variation_id=reference_config_variation_id, reference_rulesets_variation_id=reference_rulesets_variation_id, reference_ic_cell_variation_id=reference_ic_cell_variation_id)
-    perturbed_config_variation_ids = repeat(config_variation_ids, 1, length(evs))
-    perturbed_rulesets_variation_ids = repeat(rulesets_collection_variation_ids, 1, length(evs))
-    perturbed_ic_cell_variation_ids = repeat(ic_cell_variation_ids, 1, length(evs))
+    reference_variation_ids = VariationIDs(reference_config_variation_id, reference_rulesets_variation_id, reference_ic_cell_variation_id)
+    config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(method.lhs_variation, inputs, pv, reference_variation_ids)
+    perturbed_config_variation_ids = repeat(config_variation_ids, 1, length(pv.sz))
+    perturbed_rulesets_variation_ids = repeat(rulesets_collection_variation_ids, 1, length(pv.sz))
+    perturbed_ic_cell_variation_ids = repeat(ic_cell_variation_ids, 1, length(pv.sz))
     for (base_point_ind, (config_variation_id, rulesets_collection_variation_id, ic_cell_variation_id)) in enumerate(zip(config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids)) # for each base point in the LHS
-        for (par_ind, ev) in enumerate(evs) # perturb each parameter one time
-            loc = location(ev)
-            if loc == :config
-                perturbed_config_variation_ids[base_point_ind, par_ind] = perturbConfigVariation(ev, config_variation_id, inputs.config.folder)
-            elseif loc == :rulesets
-                perturbed_rulesets_variation_ids[base_point_ind, par_ind] = perturbRulesetsVariation(ev, rulesets_collection_variation_id, inputs.rulesets_collection.folder)
-            elseif loc == :ic_cell
-                perturbed_ic_cell_variation_ids[base_point_ind, par_ind] = perturbICCellVariation(ev, ic_cell_variation_id, inputs.ic_cell.folder)
-            else
-                error("Unknown variation location: $loc")
-            end
+        for d in eachindex(pv.sz) # perturb each feature one time
+            perturbed_config_variation_ids[base_point_ind, d] = perturbVariation(pv, config_variation_id, inputs.config.folder, d, :config)
+            perturbed_rulesets_variation_ids[base_point_ind, d] = perturbVariation(pv, rulesets_collection_variation_id, inputs.rulesets_collection.folder, d, :rulesets_collection)
+            perturbed_ic_cell_variation_ids[base_point_ind, d] = perturbVariation(pv, ic_cell_variation_id, inputs.ic_cell.folder, d, :ic_cell)
         end
     end
     all_config_variation_ids = hcat(config_variation_ids, perturbed_config_variation_ids)
     all_rulesets_variation_ids = hcat(rulesets_collection_variation_ids, perturbed_rulesets_variation_ids)
     all_ic_cell_variation_ids = hcat(ic_cell_variation_ids, perturbed_ic_cell_variation_ids)
     monad_dict, monad_ids = variationsToMonads(inputs, all_config_variation_ids, all_rulesets_variation_ids, all_ic_cell_variation_ids, use_previous)
-    header_line = ["base"; columnName.(evs)]
+    header_line = ["base"; columnName.(pv.variations)]
     monad_ids_df = DataFrame(monad_ids, header_line)
     sampling = Sampling(n_replicates, monad_dict |> values |> collect)
     out = run(sampling; force_recompile=force_recompile, prune_options=prune_options)
     return MOATSampling(sampling, monad_ids_df)
 end
 
-function perturbConfigVariation(ev::ElementaryVariation, config_variation_id::Int, folder::String)
-    base_value = configValue(ev, config_variation_id, folder)
-    addFn = (discrete_variation) -> gridToDB([discrete_variation], prepareConfigVariationFunctions(retrieveID("configs", folder), [discrete_variation]; reference_config_variation_id=config_variation_id)...)
-    return makePerturbation(ev, base_value, addFn)
+function perturbVariation(pv::ParsedVariations, reference_variation_id::Int, folder::String, d::Int, location::Symbol)
+    matching_dims = getfield(pv, Symbol("$(location)_variation_indices")) .== d
+    variations = getfield(pv, Symbol("$(location)_variations"))[matching_dims] # all the variations associated with the dth feature
+    if isempty(variations)
+        return reference_variation_id
+    end
+    if location == :config
+        baseValFn = configValue
+        fns = prepareConfigVariationFunctions(retrieveID("configs", folder), variations; reference_config_variation_id=reference_variation_id)
+    elseif location == :rulesets_collection
+        baseValFn = rulesetsValue
+        fns = prepareRulesetsVariationFunctions(retrieveID("rulesets_collections", folder); reference_rulesets_variation_id=reference_variation_id)
+    elseif location == :ic_cell
+        baseValFn = icCellBaseValue
+        fns = prepareICCellVariationFunctions(retrieveID("ic_cells", folder); reference_ic_cell_variation_id=reference_variation_id)
+    else
+        error("Unknown location: $location")
+    end
+    base_values = baseValFn.(variations, reference_variation_id, folder)
+    addFn = (evs) -> gridToDB(evs, fns...)
+    return makePerturbation(variations, base_values, addFn)
 end
 
-function perturbRulesetsVariation(ev::ElementaryVariation, rulesets_collection_variation_id::Int, folder::String)
-    base_value = rulesetsValue(ev, rulesets_collection_variation_id, folder)
-    addFn = (discrete_variation) -> gridToDB([discrete_variation], prepareRulesetsVariationFunctions(retrieveID("rulesets_collections", folder); reference_rulesets_variation_id=rulesets_collection_variation_id)...)
-    return makePerturbation(ev, base_value, addFn)
-end
+function makePerturbation(evs::Vector{<:ElementaryVariation}, base_values::Vector{<:Real}, addFn::Function)
+    cdfs_at_base = cdf(evs[1], base_values[1])
+    @assert all(cdf(evs[i], base_values[i]) == cdfs_at_base for i in 2:length(evs)) "All base values must have the same CDF"
+    dcdf = cdfs_at_base < 0.5 ? 0.5 : -0.5
+    new_values = _values.(evs, cdfs_at_base + dcdf) # note, this is a vector of values
 
-function perturbICCellVariation(ev::ElementaryVariation, ic_cell_variation_id::Int, folder::String)
-    base_value = icCellBaseValue(ev, ic_cell_variation_id, folder)
-    addFn = (discrete_variation) -> gridToDB([discrete_variation], prepareICCellVariationFunctions(retrieveID("ic_cells", folder); reference_ic_cell_variation_id=ic_cell_variation_id)...)
-    return makePerturbation(ev, base_value, addFn)
-end
+    discrete_variations = [DiscreteVariation(target(ev), new_value) for (ev, new_value) in zip(evs, new_values)]
 
-function makePerturbation(ev::ElementaryVariation, base_value::Real, addFn::Function)
-    cdf_at_base = cdf(ev, base_value)
-    dcdf = cdf_at_base < 0.5 ? 0.5 : -0.5
-    new_value = _values(ev, cdf_at_base + dcdf) # note, this is a vector of values
-
-    discrete_variation = DiscreteVariation(target(ev), new_value)
-
-    new_variation_id = addFn(discrete_variation)
+    new_variation_id = addFn(discrete_variations)
     @assert length(new_variation_id) == 1 "Only doing one perturbation at a time."
     return new_variation_id[1]
 end
@@ -184,13 +235,6 @@ function icCellBaseValue(column_name::String, ic_cell_variation_id::Int, folder:
     query = constructSelectQuery("ic_cell_variations", "WHERE ic_cell_variation_id=$ic_cell_variation_id;"; selection="\"$(column_name)\"")
     variation_value_df = queryToDataFrame(query; db=icCellDB(folder), is_row=true)
     return variation_value_df[1,1]
-end
-
-function calculateGSA!(moat_sampling::MOATSampling, functions::Vector{<:Function})
-    for f in functions
-        calculateGSA!(moat_sampling, f)
-    end
-    return
 end
 
 function calculateGSA!(moat_sampling::MOATSampling, f::Function)
@@ -241,6 +285,17 @@ end
 Sobolʼ(n::Int; sobol_index_methods::NamedTuple{(:first_order, :total_order), Tuple{Symbol, Symbol}}=(first_order=:Jansen1999, total_order=:Jansen1999), kwargs...) = 
     Sobolʼ(SobolVariation(n; n_matrices=2, kwargs...), sobol_index_methods)
 
+"""
+    SobolSampling
+
+Store the information that comes out of a Sobol' global sensitivity analysis.
+
+# Fields
+- `sampling::Sampling`: the sampling used in the sensitivity analysis.
+- `monad_ids_df::DataFrame`: the DataFrame of monad IDs that define the scheme of the sensitivity analysis.
+- `results::Dict{Function, GlobalSensitivity.SobolResult}`: the results of the sensitivity analysis for each function.
+- `sobol_index_methods::NamedTuple{(:first_order, :total_order), Tuple{Symbol, Symbol}}`: the methods used for calculating the first and total order indices.
+"""
 struct SobolSampling <: GSASampling
     sampling::Sampling
     monad_ids_df::DataFrame
@@ -250,7 +305,7 @@ end
 
 SobolSampling(sampling::Sampling, monad_ids_df::DataFrame; sobol_index_methods::NamedTuple{(:first_order, :total_order), Tuple{Symbol, Symbol}}=(first_order=:Jansen1999, total_order=:Jansen1999)) = SobolSampling(sampling, monad_ids_df, Dict{Function, GlobalSensitivity.SobolResult}(), sobol_index_methods)
 
-function _runSensitivitySampling(method::Sobolʼ, n_replicates::Int, inputs::InputFolders, evs::Vector{<:ElementaryVariation};
+function _runSensitivitySampling(method::Sobolʼ, n_replicates::Int, inputs::InputFolders, pv::ParsedVariations;
     reference_config_variation_id::Int=0, reference_rulesets_variation_id::Int=0,
     reference_ic_cell_variation_id::Int=inputs.ic_cell.folder=="" ? -1 : 0,
     ignore_indices::Vector{Int}=Int[], force_recompile::Bool=false, prune_options::PruneOptions=PruneOptions(), use_previous::Bool=true)
@@ -259,12 +314,9 @@ function _runSensitivitySampling(method::Sobolʼ, n_replicates::Int, inputs::Inp
     rulesets_collection_id = retrieveID("rulesets_collections", inputs.rulesets_collection.folder)
     ic_cell_id = retrieveID("ic_cells", inputs.ic_cell.folder)
     reference_variation_ids = VariationIDs(reference_config_variation_id, reference_rulesets_variation_id, reference_ic_cell_variation_id)
-    config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids, cdfs, parsed_variations =
-        addVariations(method.sobol_variation, inputs, evs, reference_variation_ids)
-    d_config = length(parsed_variations.config_variations)
-    d_rulesets = length(parsed_variations.rulesets_collection_variations)
-    d_ic_cell = length(parsed_variations.ic_cell_variations)
-    d = d_config + d_rulesets + d_ic_cell
+    config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids, cdfs =
+        addVariations(method.sobol_variation, inputs, pv, reference_variation_ids)
+    d = length(pv.sz)
     focus_indices = [i for i in 1:d if !(i in ignore_indices)]
     config_variation_ids_A = config_variation_ids[:,1]
     rulesets_variation_ids_A = rulesets_collection_variation_ids[:,1]
@@ -280,17 +332,17 @@ function _runSensitivitySampling(method::Sobolʼ, n_replicates::Int, inputs::Inp
     ic_cell_variation_ids_Aᵦ = [i => copy(ic_cell_variation_ids_A) for i in focus_indices] |> Dict
     for i in focus_indices
         Aᵦ[i][i,:] .= B[i,:]
-        if i in parsed_variations.config_variation_indices
-            fns = prepareConfigVariationFunctions(config_id, parsed_variations.config_variations; reference_config_variation_id=reference_config_variation_id)
-            config_variation_ids_Aᵦ[i][:] .= cdfsToVariations(Aᵦ[i][parsed_variations.config_variation_indices,:]', parsed_variations.config_variations, fns...)
-        elseif i in parsed_variations.rulesets_variation_indices
+        if i in pv.config_variation_indices
+            fns = prepareConfigVariationFunctions(config_id, pv.config_variations; reference_config_variation_id=reference_config_variation_id)
+            config_variation_ids_Aᵦ[i][:] .= cdfsToVariations(Aᵦ[i]', pv.config_variations, fns..., pv.config_variation_indices)
+        end
+        if i in pv.rulesets_collection_variation_indices
             fns = prepareRulesetsVariationFunctions(rulesets_collection_id; reference_rulesets_variation_id=reference_rulesets_variation_id)
-            rulesets_variation_ids_Aᵦ[i][:] .= cdfsToVariations(Aᵦ[i][parsed_variations.rulesets_variation_indices,:]', parsed_variations.rulesets_collection_variations, fns...)
-        elseif i in parsed_variations.ic_cell_variation_indices
+            rulesets_variation_ids_Aᵦ[i][:] .= cdfsToVariations(Aᵦ[i]', pv.rulesets_collection_variations, fns..., pv.rulesets_collection_variation_indices)
+        end
+        if i in pv.ic_cell_variation_indices
             fns = prepareICCellVariationFunctions(ic_cell_id; reference_ic_cell_variation_id=reference_ic_cell_variation_id)
-            ic_cell_variation_ids_Aᵦ[i][:] .= cdfsToVariations(Aᵦ[i][parsed_variations.ic_cell_variation_indices,:]', parsed_variations.ic_cell_variations, fns...)
-        else
-            throw(ArgumentError("Unknown variation index: $i"))
+            ic_cell_variation_ids_Aᵦ[i][:] .= cdfsToVariations(Aᵦ[i]', pv.ic_cell_variations, fns..., pv.ic_cell_variation_indices)
         end
     end
     all_config_variation_ids = hcat(config_variation_ids_A, config_variation_ids_B, [config_variation_ids_Aᵦ[i] for i in focus_indices]...) # make sure to the values from the dict in the expected order
@@ -298,18 +350,11 @@ function _runSensitivitySampling(method::Sobolʼ, n_replicates::Int, inputs::Inp
     all_ic_cell_variation_ids = hcat(ic_cell_variation_ids_A, ic_cell_variation_ids_B, [ic_cell_variation_ids_Aᵦ[i] for i in focus_indices]...)
     monad_dict, monad_ids = variationsToMonads(inputs, all_config_variation_ids, all_rulesets_variation_ids, all_ic_cell_variation_ids, use_previous)
     monads = monad_dict |> values |> collect
-    header_line = ["A"; "B"; columnName.(evs[focus_indices])]
+    header_line = ["A"; "B"; columnName.(pv.variations[focus_indices])]
     monad_ids_df = DataFrame(monad_ids, header_line)
     sampling = Sampling(n_replicates, monads)
     out = run(sampling; force_recompile=force_recompile, prune_options=prune_options)
     return SobolSampling(sampling, monad_ids_df; sobol_index_methods=method.sobol_index_methods)
-end
-
-function calculateGSA!(sobol_sampling::SobolSampling, functions::Vector{<:Function})
-    for f in functions
-        calculateGSA!(sobol_sampling, f)
-    end
-    return
 end
 
 function calculateGSA!(sobol_sampling::SobolSampling, f::Function)
@@ -386,6 +431,18 @@ end
 
 RBD(n::Integer; num_harmonics::Integer=6, kwargs...) = RBD(RBDVariation(n; kwargs...), num_harmonics)
 
+"""
+    RBDSampling
+
+Store the information that comes out of a Random Balance Design (RBD) global sensitivity analysis.
+
+# Fields
+- `sampling::Sampling`: the sampling used in the sensitivity analysis.
+- `monad_ids_df::DataFrame`: the DataFrame of monad IDs that define the scheme of the sensitivity analysis.
+- `results::Dict{Function, GlobalSensitivity.SobolResult}`: the results of the sensitivity analysis for each function.
+- `num_harmonics::Int`: the number of harmonics used in the Fourier transform.
+- `num_cycles::Union{Int, Rational}`: the number of cycles used for each parameter.
+"""
 struct RBDSampling <: GSASampling
     sampling::Sampling
     monad_ids_df::DataFrame
@@ -396,27 +453,21 @@ end
 
 RBDSampling(sampling::Sampling, monad_ids_df::DataFrame, num_cycles; num_harmonics::Int=6) = RBDSampling(sampling, monad_ids_df, Dict{Function, GlobalSensitivity.SobolResult}(), num_harmonics, num_cycles)
 
-function _runSensitivitySampling(method::RBD, n_replicates::Int, inputs::InputFolders, evs::Vector{<:ElementaryVariation};
+function _runSensitivitySampling(method::RBD, n_replicates::Int, inputs::InputFolders, pv::ParsedVariations;
     reference_config_variation_id::Int=0, reference_rulesets_variation_id::Int=0, reference_ic_cell_variation_id::Int=inputs.ic_cell.folder=="" ? -1 : 0,
     ignore_indices::Vector{Int}=Int[], force_recompile::Bool=false, prune_options::PruneOptions=PruneOptions(), use_previous::Bool=true)
     if !isempty(ignore_indices)
         error("RBD does not support ignoring indices...yet? Only Sobolʼ does for now.")
     end
-    config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids, config_variations_matrix, rulesets_variations_matrix, ic_cell_variations_matrix = addVariations(method.rbd_variation, inputs, evs; reference_config_variation_id=reference_config_variation_id, reference_rulesets_variation_id=reference_rulesets_variation_id, reference_ic_cell_variation_id=reference_ic_cell_variation_id)
+    reference_variation_ids = VariationIDs(reference_config_variation_id, reference_rulesets_variation_id, reference_ic_cell_variation_id)
+    config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids, config_variations_matrix, rulesets_variations_matrix, ic_cell_variations_matrix = addVariations(method.rbd_variation, inputs, pv, reference_variation_ids)
     monad_dict, monad_ids = variationsToMonads(inputs, config_variations_matrix, rulesets_variations_matrix, ic_cell_variations_matrix, use_previous)
     monads = monad_dict |> values |> collect
-    header_line = columnName.(evs)
+    header_line = columnName.(pv.variations)
     monad_ids_df = DataFrame(monad_ids, header_line)
     sampling = Sampling(n_replicates, monads)
     out = run(sampling; force_recompile=force_recompile, prune_options=prune_options)
     return RBDSampling(sampling, monad_ids_df, method.rbd_variation.num_cycles; num_harmonics=method.num_harmonics)
-end
-
-function calculateGSA!(rbd_sampling::RBDSampling, functions::Vector{<:Function})
-    for f in functions
-        calculateGSA!(rbd_sampling, f)
-    end
-    return
 end
 
 function calculateGSA!(rbd_sampling::RBDSampling, f::Function)

--- a/src/VCTUserAPI.jl
+++ b/src/VCTUserAPI.jl
@@ -3,27 +3,30 @@ import Base.run
 export createTrial
 
 """
-    createTrial(inputs::InputFolders, evs::Vector{<:ElementaryVariation}=ElementaryVariation[]; n_replicates::Integer=1,
-                use_previous::Bool=true)
+    createTrial([method=GridVariation()], inputs::InputFolders, avs::Vector{<:AbstractVariation}=AbstractVariation[];
+                n_replicates::Integer=1, use_previous::Bool=true)
 
 Return an object of type `<:AbstractTrial` (simulation, monad, sampling, trial) with the given input folders and elementary variations.
 
-Uses the `evs` and `n_replicates` to determine whether to create a simulation, monad, or sampling.
+Uses the `avs` and `n_replicates` to determine whether to create a simulation, monad, or sampling.
 Despite its name, trials cannot yet be created by this function.
 If `n_replicates` is 0, and each variation has a single value, a simulation will be created.
 
-Alternate forms:
-Only supplying a single `ElementaryVariation`:
+By default, the `method` is `GridVariation()`, which creates a grid of variations from the vector `avs`.
+Other methods are: [`LHSVariation`](@ref), [`SobolVariation`](@ref), and [`RBDVariation`](@ref).
+
+Alternate forms (all work with the optional `method` argument in the first position):
+Only supplying a single `AbstractVariation`:
 ```
-createTrial(inputs::InputFolders, ev::ElementaryVariation; n_replicates::Integer=1, use_previous::Bool=true)
+createTrial(inputs::InputFolders, av::AbstractVariation; n_replicates::Integer=1, use_previous::Bool=true)
 ```
 Using a reference simulation or monad:
 ```
-createTrial(reference::AbstractMonad, evs::Vector{<:ElementaryVariation}=ElementaryVariation[]; n_replicates::Integer=1,
+createTrial(reference::AbstractMonad, avs::Vector{<:AbstractVariation}=AbstractVariation[]; n_replicates::Integer=1,
             use_previous::Bool=true)
 ```
 ```
-createTrial(reference::AbstractMonad, ev::ElementaryVariation; n_replicates::Integer=1, use_previous::Bool=true)
+createTrial(reference::AbstractMonad, av::AbstractVariation; n_replicates::Integer=1, use_previous::Bool=true)
 ```
 
 # Examples
@@ -36,26 +39,33 @@ monad = createTrial(inputs, dv_max_time; n_replicates=2)
 sampling = createTrial(monad, dv_apoptosis; n_replicates=2) # uses the max time defined for monad
 ```
 """
-function createTrial(inputs::InputFolders, evs::Vector{<:ElementaryVariation}=ElementaryVariation[]; n_replicates::Integer=1,
-                     use_previous::Bool=true)
-    return _createTrial(inputs, VariationIDs(inputs), evs, n_replicates, use_previous)
+function createTrial(method::AddVariationMethod, inputs::InputFolders, avs::Vector{<:AbstractVariation}=AbstractVariation[];
+    n_replicates::Integer=1, use_previous::Bool=true)
+    return _createTrial(method, inputs, VariationIDs(inputs), avs, n_replicates, use_previous)
 end
 
-function createTrial(inputs::InputFolders, ev::ElementaryVariation; n_replicates::Integer=1, use_previous::Bool=true)
-    return _createTrial(inputs, VariationIDs(inputs), [ev], n_replicates, use_previous)
+function createTrial(method::AddVariationMethod, inputs::InputFolders, av::AbstractVariation; kwargs...)
+    return createTrial(method, inputs, [av]; kwargs...)
 end
 
-function createTrial(reference::AbstractMonad, evs::Vector{<:ElementaryVariation}=ElementaryVariation[]; n_replicates::Integer=1,
-    use_previous::Bool=true)
-    return _createTrial(reference.inputs, reference.variation_ids, evs, n_replicates, use_previous)
+createTrial(inputs::InputFolders, args...; kwargs...) = createTrial(GridVariation(), inputs, args...; kwargs...)
+
+
+function createTrial(method::AddVariationMethod, reference::AbstractMonad, avs::Vector{<:AbstractVariation}=AbstractVariation[];
+                     n_replicates::Integer=1, use_previous::Bool=true)
+    return _createTrial(method, reference.inputs, reference.variation_ids, avs, n_replicates, use_previous)
 end
 
-function createTrial(reference::AbstractMonad, ev::ElementaryVariation; n_replicates::Integer=1, use_previous::Bool=true)
-    return _createTrial(reference.inputs, reference.variation_ids, [ev], n_replicates, use_previous)
+function createTrial(method::AddVariationMethod, reference::AbstractMonad, av::AbstractVariation; kwargs...)
+    return createTrial(method, reference, [av]; kwargs...)
 end
 
-function _createTrial(inputs::InputFolders, reference_variation_ids::VariationIDs, evs::Vector{<:ElementaryVariation}, n_replicates::Integer, use_previous::Bool)
-    config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(GridVariation(), inputs, evs, reference_variation_ids)
+createTrial(reference::AbstractMonad, args...; kwargs...) = createTrial(GridVariation(), reference, args...; kwargs...)
+
+function _createTrial(method::AddVariationMethod, inputs::InputFolders, reference_variation_ids::VariationIDs,
+                      avs::Vector{<:AbstractVariation}, n_replicates::Integer, use_previous::Bool)
+                      
+    config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids = addVariations(method, inputs, avs, reference_variation_ids)
     if length(config_variation_ids) == 1
         variation_ids = VariationIDs(config_variation_ids[1], rulesets_collection_variation_ids[1], ic_cell_variation_ids[1])
         monad = Monad(n_replicates, inputs, variation_ids, use_previous)
@@ -77,13 +87,14 @@ end
 
 Run a simulation, monad, sampling, or trial with the same signatures available to [`createTrial`](@ref).
 """
-function run(inputs::InputFolders, args...; force_recompile::Bool=false, prune_options::PruneOptions=PruneOptions(), kwargs...)
-    trial = createTrial(inputs, args...; kwargs...)
+function run(method::AddVariationMethod, args...; force_recompile::Bool=false, 
+             prune_options::PruneOptions=PruneOptions(), kwargs...)
+    trial = createTrial(method, args...; kwargs...)
     return run(trial; force_recompile=force_recompile, prune_options=prune_options)
 end
 
-function run(reference::AbstractMonad, evs::Union{ElementaryVariation,Vector{<:ElementaryVariation}}; n_replicates::Integer=1,
-             use_previous::Bool=true, force_recompile::Bool=false, prune_options::PruneOptions=PruneOptions())
-    trial = createTrial(reference, evs; n_replicates=n_replicates, use_previous=use_previous)
-    return run(trial; force_recompile=force_recompile, prune_options=prune_options)
+run(inputs::InputFolders, args...; kwargs...) = run(GridVariation(), inputs, args...; kwargs...)
+
+function run(reference::AbstractMonad, avs::Union{AbstractVariation,Vector{<:AbstractVariation}}; kwargs...)
+    return run(GridVariation(), reference, avs; kwargs...)
 end

--- a/src/VCTVariations.jl
+++ b/src/VCTVariations.jl
@@ -1,7 +1,7 @@
-using Distributions
+using Distributions, LazyGrids
 import Distributions: cdf
 
-export ElementaryVariation, DiscreteVariation, DistributedVariation
+export ElementaryVariation, DiscreteVariation, DistributedVariation, CoVariation
 export UniformDistributedVariation, NormalDistributedVariation
 export GridVariation, LHSVariation, SobolVariation
 
@@ -50,6 +50,7 @@ struct DiscreteVariation{T} <: ElementaryVariation
         return new{T}(location, target, values)
     end
 end
+
 DiscreteVariation(xml_path::Vector{<:AbstractString}, value::T) where T = DiscreteVariation(xml_path, [value])
 
 Base.length(discrete_variation::DiscreteVariation) = length(discrete_variation.values)
@@ -71,24 +72,33 @@ Alternatively, users can use the [`UniformDistributedVariation`](@ref) and [`Nor
 - `location::Symbol`: The location of the variation. Can be `:config`, `:rulesets`, or `:ic_cell`. The location is inferred from the target.
 - `target::Vector{<:AbstractString}`: The target of the variation. The target is a vector of strings that represent the XML path to the element being varied.
 - `distribution::Distribution`: The distribution of the variation.
+- `flip::Bool=false`: Whether to flip the distribution, i.e., when asked for the iCDF of `x`, return the iCDF of `1-x`. Useful for [`CoVariation`](@ref)'s.
 
 # Examples
 ```jldoctest
 using Distributions
 d = Uniform(1, 2)
-DistributedVariation([pcvct.apoptosisPath("default"); "rate"], d)
+DistributedVariation([pcvct.apoptosisPath("default"); "death_rate"], d)
 # output
-DistributedVariation(:config, ["cell_definitions", "cell_definition:name:default", "phenotype", "death", "model:code:100", "rate"], Distributions.Uniform{Float64}(a=1.0, b=2.0))
+DistributedVariation(:config, ["cell_definitions", "cell_definition:name:default", "phenotype", "death", "model:code:100", "death_rate"], Distributions.Uniform{Float64}(a=1.0, b=2.0), false)
 ```
+```jldoctest
+using Distributions
+d = Uniform(1, 2)
+flip = true # the cdf on this variation will decrease from 1 to 0 as the value increases from 1 to 2
+DistributedVariation([pcvct.necrosisPath("default"); "death_rate"], d, flip)
+# output
+DistributedVariation(:config, ["cell_definitions", "cell_definition:name:default", "phenotype", "death", "model:code:101", "death_rate"], Distributions.Uniform{Float64}(a=1.0, b=2.0), true)
 """
 struct DistributedVariation <: ElementaryVariation
     location::Symbol
     target::Vector{<:AbstractString}
     distribution::Distribution
+    flip::Bool
 
-    function DistributedVariation(target::Vector{<:AbstractString}, distribution::Distribution)
+    function DistributedVariation(target::Vector{<:AbstractString}, distribution::Distribution, flip::Bool=false)
         location = variationLocation(target)
-        return new(location, target, distribution)
+        return new(location, target, distribution, flip)
     end
 end
 
@@ -96,13 +106,15 @@ target(ev::ElementaryVariation) = ev.target::Vector{<:AbstractString}
 location(ev::ElementaryVariation) = ev.location
 columnName(ev::ElementaryVariation) = target(ev) |> xmlPathToColumnName
 
+Base.length(::DistributedVariation) = -1 # set to -1 to be a convention
+
 """
     UniformDistributedVariation(xml_path::Vector{<:AbstractString}, lb::T, ub::T) where {T<:Real}
 
 Create a distributed variation with a uniform distribution.
 """
-function UniformDistributedVariation(xml_path::Vector{<:AbstractString}, lb::T, ub::T) where {T<:Real}
-    return DistributedVariation(xml_path, Uniform(lb, ub))
+function UniformDistributedVariation(xml_path::Vector{<:AbstractString}, lb::T, ub::T, flip::Bool=false) where {T<:Real}
+    return DistributedVariation(xml_path, Uniform(lb, ub), flip)
 end
 
 """
@@ -110,8 +122,8 @@ end
 
 Create a (possibly truncated) distributed variation with a normal distribution.
 """
-function NormalDistributedVariation(xml_path::Vector{<:AbstractString}, mu::T, sigma::T; lb::Real=-Inf, ub::Real=Inf) where {T<:Real}
-    return DistributedVariation(xml_path, truncated(Normal(mu, sigma), lb, ub))
+function NormalDistributedVariation(xml_path::Vector{<:AbstractString}, mu::T, sigma::T, flip::Bool=false; lb::Real=-Inf, ub::Real=Inf) where {T<:Real}
+    return DistributedVariation(xml_path, truncated(Normal(mu, sigma), lb, ub), flip)
 end
 
 _values(discrete_variation::DiscreteVariation) = discrete_variation.values
@@ -125,7 +137,7 @@ end
 _values(discrete_variation::DiscreteVariation, cdf::Real) = _values(discrete_variation, [cdf])
 
 function _values(dv::DistributedVariation, cdf::Vector{<:Real})
-    return map(Base.Fix1(quantile, dv.distribution), cdf)
+    return map(Base.Fix1(quantile, dv.distribution), dv.flip ? 1 .- cdf : cdf)
 end
 
 _values(dv::DistributedVariation, cdf::Real) = _values(dv, [cdf])
@@ -150,7 +162,13 @@ function cdf(discrete_variation::DiscreteVariation, x::Real)
     return (findfirst(isequal(x), discrete_variation.values) - 1) / (length(discrete_variation) - 1)
 end
 
-cdf(dv::DistributedVariation, x::Real) = cdf(dv.distribution, x)
+function cdf(dv::DistributedVariation, x::Real)
+    out = cdf(dv.distribution, x)
+    if dv.flip
+        return 1 - out
+    end
+    return out
+end
 
 cdf(ev::ElementaryVariation, ::Real) = error("cdf not defined for $(typeof(ev))")
 
@@ -162,6 +180,64 @@ function variationLocation(xml_path::Vector{<:AbstractString})
     else
         return :config
     end
+end
+
+################## Co-Variations ##################
+
+"""
+    CoVariation
+
+A co-variation of one or more variations.
+
+# Fields
+- `variations::Vector{T}`: The variations that make up the co-variation.
+"""
+struct CoVariation{T<:ElementaryVariation} <: AbstractVariation
+    variations::Vector{T}
+
+    function CoVariation(inputs::Vararg{Tuple{Vector{<:AbstractString},Distribution},N}) where {N}
+        variations = DistributedVariation[]
+        for (xml_path, distribution) in inputs
+            @assert xml_path isa Vector{<:AbstractString} "xml_path must be a vector of strings"
+            push!(variations, DistributedVariation(xml_path, distribution))
+        end
+        return new{DistributedVariation}(variations)
+    end
+    function CoVariation(inputs::Vararg{Tuple{Vector{<:AbstractString},Vector},N}) where {N}
+        variations = DiscreteVariation[]
+        n_discrete = -1
+        for (xml_path, val) in inputs
+            n_vals = length(val)
+            if n_discrete == -1
+                n_discrete = n_vals
+            else
+                @assert n_discrete == n_vals "All discrete vals must have the same length"
+            end
+            push!(variations, DiscreteVariation(xml_path, val))
+        end
+        return new{DiscreteVariation}(variations)
+    end
+    function CoVariation(ev::T) where {T<:ElementaryVariation}
+        return new{T}([ev])
+    end
+    function CoVariation(evs::Vector{T}) where {T<:ElementaryVariation}
+        if T == DistributedVariation
+            return new{T}(evs)
+        end
+        @assert (length.(evs) |> unique |> length) == 1 "All DiscreteVariations in a CoVariation must have the same length."
+        return new{DiscreteVariation}(evs)
+    end
+    function CoVariation(inputs::Vararg{T,N}) where {T<:ElementaryVariation,N}
+        return CoVariation(Vector{T}([inputs...]))
+    end
+end
+
+target(cv::CoVariation) = target.(cv.variations)
+location(cv::CoVariation) = location.(cv.variations)
+columnName(cv::CoVariation) = columnName.(cv.variations) |> x->join(x, " AND ")
+
+function Base.length(cv::CoVariation)
+    return length(cv.variations[1])
 end
 
 ################## Database Interface Functions ##################
@@ -368,18 +444,7 @@ LHSVariation(; n::Int=4, add_noise::Bool=false, rng::AbstractRNG=Random.GLOBAL_R
 
 A variation method that creates a Sobol sequence of the values of the variations.
 
-The subsequence of the Sobol sequence is chosen based on the value of `n` and the value of `include_one`.
-If it is one less than a power of 2, e.g. `n=7`, skip 0 and start from 0.5.
-Otherwise, it will always start from 0.
-If it is one more than a power of 2, e.g. `n=9`, include 1 (unless `include_one` is `false`).
-
-The `skip_start` field can be used to control this by skipping the start of the sequence.
-If `skip_start` is `true`, skip to the smallest consecutive subsequence with the same denominator that has at least `n` elements.
-If `skip_start` is `false`, start from 0.
-If `skip_start` is an integer, skip that many elements in the sequence, .e.g., `skip_start=1` skips 0 and starts at 0.5.
-
-If you want to include 1 in the sequence, set `include_one` to `true`.
-If you want to exlude 1 (in the case of `n=9`, e.g.), set `include_one` to `false`.
+See [`generateSobolCDFs`](@ref) for more information on how the Sobol sequence is generated based on `n` and the other fields.
 
 See the GlobalSensitivity.jl package for more information on `RandomizationMethod`'s to use.
 
@@ -478,90 +543,123 @@ end
 
 RBDVariation(n::Int; rng::AbstractRNG=Random.GLOBAL_RNG, use_sobol::Bool=true, pow2_diff=missing, num_cycles=missing) = RBDVariation(n, rng, use_sobol, pow2_diff, num_cycles)
 
-function addVariations(method::AddVariationMethod, inputs::InputFolders, evs::Vector{<:ElementaryVariation};
+function addVariations(method::AddVariationMethod, inputs::InputFolders, avs::Vector{<:AbstractVariation};
     reference_config_variation_id::Int=0, reference_rulesets_variation_id::Int=0, reference_ic_cell_variation_id::Int=inputs.ic_cell.folder=="" ? -1 : 0)
     reference_variation_ids = VariationIDs(reference_config_variation_id, reference_rulesets_variation_id, reference_ic_cell_variation_id)
-    return addVariations(method, inputs, evs, reference_variation_ids)
+    return addVariations(method, inputs, avs, reference_variation_ids)
+end
+
+function addVariations(method::AddVariationMethod, inputs::InputFolders, avs::Vector{<:AbstractVariation}, reference_variation_ids::VariationIDs)
+    pv = ParsedVariations(avs)
+    return addVariations(method, inputs, pv, reference_variation_ids)
 end
 
 struct ParsedVariations
+    sz::Vector{Int}
+    variations::Vector{<:AbstractVariation} # 
+
     config_variations::Vector{<:ElementaryVariation}
     rulesets_collection_variations::Vector{<:ElementaryVariation}
     ic_cell_variations::Vector{<:ElementaryVariation}
 
     config_variation_indices::Vector{Int}
-    rulesets_variation_indices::Vector{Int}
+    rulesets_collection_variation_indices::Vector{Int}
     ic_cell_variation_indices::Vector{Int}
 
-    function ParsedVariations(config_variations::Vector{<:ElementaryVariation}, rulesets_collection_variations::Vector{<:ElementaryVariation}, ic_cell_variations::Vector{<:ElementaryVariation}, config_variation_indices::Vector{Int}, rulesets_variation_indices::Vector{Int}, ic_cell_variation_indices::Vector{Int})
+    function ParsedVariations(sz::Vector{Int}, variations::Vector{<:AbstractVariation}, config_variations::Vector{<:ElementaryVariation}, rulesets_collection_variations::Vector{<:ElementaryVariation}, ic_cell_variations::Vector{<:ElementaryVariation}, config_variation_indices::Vector{Int}, rulesets_collection_variation_indices::Vector{Int}, ic_cell_variation_indices::Vector{Int})
         @assert length(config_variations) == length(config_variation_indices) "config_variations and config_variation_indices must have the same length"
-        @assert length(rulesets_collection_variations) == length(rulesets_variation_indices) "rulesets_collection_variations and rulesets_variation_indices must have the same length"
+        @assert length(rulesets_collection_variations) == length(rulesets_collection_variation_indices) "rulesets_collection_variations and rulesets_collection_variation_indices must have the same length"
         @assert length(ic_cell_variations) == length(ic_cell_variation_indices) "ic_cell_variations and ic_cell_variation_indices must have the same length"
-        return new(config_variations, rulesets_collection_variations, ic_cell_variations, config_variation_indices, rulesets_variation_indices, ic_cell_variation_indices)
+        return new(sz, variations, config_variations, rulesets_collection_variations, ic_cell_variations, config_variation_indices, rulesets_collection_variation_indices, ic_cell_variation_indices)
     end
 end
 
-function ParsedVariations(evs::Vector{<:ElementaryVariation})
+function ParsedVariations(avs::Vector{<:AbstractVariation})
+    sz = length.(avs)
+
     config_variations = ElementaryVariation[]
     rulesets_collection_variations = ElementaryVariation[]
     ic_cell_variations = ElementaryVariation[]
     config_variation_indices = Int[]
-    rulesets_variation_indices = Int[]
+    rulesets_collection_variation_indices = Int[]
     ic_cell_variation_indices = Int[]
-    for (i, ev) in enumerate(evs)
-        loc = location(ev)
-        if loc == :config
-            push!(config_variations, ev)
-            push!(config_variation_indices, i)
-        elseif loc == :rulesets
-            push!(rulesets_collection_variations, ev)
-            push!(rulesets_variation_indices, i)
-        elseif loc == :ic_cell
-            push!(ic_cell_variations, ev)
-            push!(ic_cell_variation_indices, i)
-        else
-            error("Variation type not recognized.")
+    for (i, av) in enumerate(avs)
+        if av isa ElementaryVariation
+            av = CoVariation(av) # wrap it in a covariation
+        end
+        @assert av isa CoVariation "Everything at this point should have been converted to a CoVariation"
+        for ev in av.variations
+            loc = location(ev)
+            if loc == :config
+                push!(config_variations, ev)
+                push!(config_variation_indices, i)
+            elseif loc == :rulesets
+                push!(rulesets_collection_variations, ev)
+                push!(rulesets_collection_variation_indices, i)
+            elseif loc == :ic_cell
+                push!(ic_cell_variations, ev)
+                push!(ic_cell_variation_indices, i)
+            else
+                error("Variation type not recognized.")
+            end
         end
     end
-    return ParsedVariations(config_variations, rulesets_collection_variations, ic_cell_variations, config_variation_indices, rulesets_variation_indices, ic_cell_variation_indices)
+    for v in [config_variation_indices, rulesets_collection_variation_indices, ic_cell_variation_indices]
+        @assert issorted(v) "Variation indices must be sorted after parsing."
+    end
+    return ParsedVariations(sz, avs, config_variations, rulesets_collection_variations, ic_cell_variations, config_variation_indices, rulesets_collection_variation_indices, ic_cell_variation_indices)
 end
 
 ################## Grid Variations ##################
 
-function addVariations(::GridVariation, inputs::InputFolders, evs::Vector{<:ElementaryVariation}, reference_variation_ids::VariationIDs)
-    pvs = ParsedVariations(evs)
-    if isempty(pvs.config_variations)
-        config_variation_ids = [reference_variation_ids.config]
-    else
-        config_variation_ids = gridToDB(pvs.config_variations, prepareConfigVariationFunctions(inputs.config.id, pvs.config_variations; reference_config_variation_id=reference_variation_ids.config)...)
-    end
-    if isempty(pvs.rulesets_collection_variations)
-        rulesets_collection_variation_ids = [reference_variation_ids.rulesets_collection]
-    else
-        rulesets_collection_variation_ids = gridToDB(pvs.rulesets_collection_variations, prepareRulesetsVariationFunctions(inputs.rulesets_collection.id; reference_rulesets_variation_id=reference_variation_ids.rulesets_collection)...)
-    end
-    if isempty(pvs.ic_cell_variations)
-        ic_cell_variation_ids = [reference_variation_ids.ic_cell]
-    else
-        ic_cell_variation_ids = gridToDB(pvs.ic_cell_variations, prepareICCellVariationFunctions(inputs.ic_cell.id; reference_ic_cell_variation_id=reference_variation_ids.ic_cell)...)
-    end
-    all_config_variation_ids, all_rulesets_variation_ids, all_ic_cell_variation_ids = ndgrid(config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids)
-    return all_config_variation_ids, all_rulesets_variation_ids, all_ic_cell_variation_ids
+function addVariations(::GridVariation, inputs::InputFolders, pv::ParsedVariations, reference_variation_ids::VariationIDs)
+    @assert all(pv.sz .!= -1) "GridVariation only works with DiscreteVariations"
+    return [addLocationGridVariations(inputs, pv, reference_variation_ids, location) for location in [:config, :rulesets_collection, :ic_cell]]
 end
 
-function gridToDB(evs::Vector{<:ElementaryVariation}, addColumnsByPathsFn::Function, prepareAddNewFn::Function, addRowFn::Function)
-    new_values = _values.(evs)
+function addLocationGridVariations(inputs::InputFolders, pv::ParsedVariations, reference_variation_ids::VariationIDs, location::Symbol)
+    variations_field = Symbol("$(location)_variations")
+    if isempty(getfield(pv, variations_field))
+        return fill(getfield(reference_variation_ids, location), pv.sz...)
+    end
+    variation_indices_field = Symbol("$(location)_variation_indices")
+    fns = prepareVariationFunctions(location, inputs, pv, reference_variation_ids)
+    out = gridToDB(getfield(pv, variations_field), fns..., getfield(pv, variation_indices_field))
+    dim_szs = [d in getfield(pv, variation_indices_field) ? pv.sz[d] : 1 for d in eachindex(pv.sz)]
+    out = reshape(out, dim_szs...)
 
+    other_dims = [dim_szs[d] == 1 ? pv.sz[d] : 1 for d in eachindex(pv.sz)]
+    return repeat(out, other_dims...)
+end
+
+function prepareVariationFunctions(location::Symbol, inputs::InputFolders, pv::ParsedVariations, reference_variation_ids::VariationIDs)
+    if location == :config
+        return prepareConfigVariationFunctions(inputs.config.id, pv.config_variations; reference_config_variation_id=reference_variation_ids.config)
+    elseif location == :rulesets_collection
+        return prepareRulesetsVariationFunctions(inputs.rulesets_collection.id; reference_rulesets_variation_id=reference_variation_ids.rulesets_collection)
+    elseif location == :ic_cell
+        return prepareICCellVariationFunctions(inputs.ic_cell.id; reference_ic_cell_variation_id=reference_variation_ids.ic_cell)
+    end
+end
+
+function gridToDB(evs::Vector{<:ElementaryVariation}, addColumnsByPathsFn::Function, prepareAddNewFn::Function, addRowFn::Function, ev_dims::AbstractVector{Int}=1:length(evs))
     static_values, table_features = setUpColumns(evs, addColumnsByPathsFn, prepareAddNewFn)
+    
+    all_values = []
+    for ev_dim in unique(ev_dims)
+        dim_indices = findall(ev_dim .== ev_dims)
+        push!(all_values, zip(_values.(evs[dim_indices])...))
+    end
 
-    NDG = ndgrid(new_values...)
+    NDG = ndgrid(collect.(all_values)...)
     sz_variations = size(NDG[1])
     variation_ids = zeros(Int, sz_variations)
     for i in eachindex(NDG[1])
-        varied_values = [A[i] for A in NDG] .|> string |> x -> join("\"" .* x .* "\"", ",")
+        dim_vals_as_vecs = [[A[i]...] for A in NDG] # ith entry is a vector of the values for the ith dimension
+        varied_values = vcat(dim_vals_as_vecs...) .|> string |> x -> join("\"" .* x .* "\"", ",")
         variation_ids[i] = addRowFn(table_features, static_values, varied_values)
     end
-    return variation_ids |> vec
+    return variation_ids
 end
 
 ################## Latin Hypercube Sampling Functions ##################
@@ -619,42 +717,102 @@ end
 #     end
 # end
 
-function generateLHSCDFs(n::Int, d::Int; add_noise::Bool=false, rng::AbstractRNG=Random.GLOBAL_RNG=rng, orthogonalize::Bool=true)
+"""
+    generateLHSCDFs(n::Int, d::Int[; add_noise::Bool=false, rng::AbstractRNG=Random.GLOBAL_RNG, orthogonalize::Bool=true])
+
+Generate a Latin Hypercube Sample of the Cumulative Distribution Functions (CDFs) for `n` samples in `d` dimensions.
+
+# Arguments
+- `n::Int`: The number of samples to take.
+- `d::Int`: The number of dimensions to sample.
+- `add_noise::Bool=false`: Whether to add noise to the samples or have them be in the center of the bins.
+- `rng::AbstractRNG=Random.GLOBAL_RNG`: The random number generator to use.
+- `orthogonalize::Bool=true`: Whether to orthogonalize the samples, if possible. See https://en.wikipedia.org/wiki/Latin_hypercube_sampling#:~:text=In%20orthogonal%20sampling
+
+# Returns
+- `cdfs::Matrix{Float64}`: The CDFs for the samples. Each row is a sample and each column is a dimension (corresponding to a feature).
+
+# Examples
+```jldoctest
+cdfs = pcvct.generateLHSCDFs(4, 2)
+size(cdfs)
+# output
+(4, 2)
+```
+"""
+function generateLHSCDFs(n::Int, d::Int; add_noise::Bool=false, rng::AbstractRNG=Random.GLOBAL_RNG, orthogonalize::Bool=true)
     cdfs = (Float64.(1:n) .- (add_noise ? rand(rng, Float64, n) : 0.5)) / n # permute below for each parameter separately
     k = n ^ (1 / d) |> round |> Int
     if orthogonalize && (n == k^d)
         # then good to do the orthogonalization
         lhs_inds = orthogonalLHS(k, d)
     else
-        lhs_inds = hcat([shuffle(rng, 1:n) for _ in 1:d]...)
+        lhs_inds = reduce(hcat, [shuffle(rng, 1:n) for _ in 1:d]) # each shuffled index vector is added as a column
     end
     return cdfs[lhs_inds]
 end
 
-function addVariations(lhs_variation::LHSVariation, inputs::InputFolders, evs::Vector{<:ElementaryVariation}, reference_variation_ids::VariationIDs)
-    pvs = ParsedVariations(evs)
-    d = length(pvs.config_variations) + length(pvs.rulesets_collection_variations) + length(pvs.ic_cell_variations)
+function addVariations(lhs_variation::LHSVariation, inputs::InputFolders, pv::ParsedVariations, reference_variation_ids::VariationIDs)
+    d = length(pv.sz)
     cdfs = generateLHSCDFs(lhs_variation.n, d; add_noise=lhs_variation.add_noise, rng=lhs_variation.rng, orthogonalize=lhs_variation.orthogonalize)
-    if isempty(pvs.config_variations)
-        config_variation_ids = fill(reference_variation_ids.config, lhs_variation.n)
-    else
-        config_variation_ids = cdfsToVariations(cdfs[:, 1:length(pvs.config_variations)], pvs.config_variations, prepareConfigVariationFunctions(inputs.config.id, pvs.config_variations; reference_config_variation_id=reference_variation_ids.config)...)
+    return [addLocationCDFVariations(inputs, pv, reference_variation_ids, location, cdfs) for location in [:config, :rulesets_collection, :ic_cell]]
+end
+
+function addLocationCDFVariations(inputs::InputFolders, pv::ParsedVariations, reference_variation_ids::VariationIDs, location::Symbol, cdfs::AbstractMatrix{Float64})
+    variations_field = Symbol("$(location)_variations")
+    if isempty(getfield(pv, variations_field))
+        return fill(getfield(reference_variation_ids, location), size(cdfs, 1))
     end
-    if isempty(pvs.rulesets_collection_variations)
-        rulesets_collection_variation_ids = fill(reference_variation_ids.rulesets_collection, lhs_variation.n)
-    else
-        rulesets_collection_variation_ids = cdfsToVariations(cdfs[:, length(pvs.config_variations)+1:end], pvs.rulesets_collection_variations, prepareRulesetsVariationFunctions(inputs.rulesets_collection.id; reference_rulesets_variation_id=reference_variation_ids.rulesets_collection)...)
-    end
-    if isempty(pvs.ic_cell_variations)
-        ic_cell_variation_ids = fill(reference_variation_ids.ic_cell, lhs_variation.n)
-    else
-        ic_cell_variation_ids = cdfsToVariations(cdfs[:, length(pvs.config_variations)+length(pvs.rulesets_collection_variations)+1:end], pvs.ic_cell_variations, prepareICCellVariationFunctions(inputs.ic_cell.id; reference_ic_cell_variation_id=reference_variation_ids.ic_cell)...)
-    end
-    return config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids
+    variation_indices_field = Symbol("$(location)_variation_indices")
+    fns = prepareVariationFunctions(location, inputs, pv, reference_variation_ids)
+    return cdfsToVariations(cdfs, getfield(pv, variations_field), fns..., getfield(pv, variation_indices_field))
 end
 
 ################## Sobol Sequence Sampling Functions ##################
 
+"""
+    generateSobolCDFs(n::Int, d::Int[; n_matrices::Int=1, randomization::RandomizationMethod=NoRand(), skip_start::Union{Missing, Bool, Int}=missing, include_one::Union{Missing, Bool}=missing)
+
+Generate `n_matrices` Sobol sequences of the Cumulative Distribution Functions (CDFs) for `n` samples in `d` dimensions.
+
+The subsequence of the Sobol sequence is chosen based on the value of `n` and the value of `include_one`.
+If it is one less than a power of 2, e.g. `n=7`, skip 0 and start from 0.5.
+Otherwise, it will always start from 0.
+If it is one more than a power of 2, e.g. `n=9`, include 1 (unless `include_one` is `false`).
+
+The `skip_start` field can be used to control this by skipping the start of the sequence.
+If `skip_start` is `true`, skip to the smallest consecutive subsequence with the same denominator that has at least `n` elements.
+If `skip_start` is `false`, start from 0.
+If `skip_start` is an integer, skip that many elements in the sequence, .e.g., `skip_start=1` skips 0 and starts at 0.5.
+
+If you want to include 1 in the sequence, set `include_one` to `true`.
+If you want to exlude 1 (in the case of `n=9`, e.g.), set `include_one` to `false`.
+
+# Arguments
+- `n::Int`: The number of samples to take.
+- `d::Int`: The number of dimensions to sample.
+- `n_matrices::Int=1`: The number of matrices to use in the Sobol sequence (effectively, the dimension of the sample is `d` x `n_matrices`).
+- `randomization::RandomizationMethod=NoRand()`: The randomization method to use on the deterministic Sobol sequence. See GlobalSensitivity.jl.
+- `skip_start::Union{Missing, Bool, Int}=missing`: Whether to skip the start of the sequence. Missing means pcvct will choose the best option.
+- `include_one::Union{Missing, Bool}=missing`: Whether to include 1 in the sequence. Missing means pcvct will choose the best option.
+
+# Returns
+- `cdfs::Array{Float64, 3}`: The CDFs for the samples. The first dimension is the features, the second dimension is the matrix, and the third dimension is the sample points.
+
+# Examples
+```jldoctest
+cdfs = pcvct.generateSobolCDFs(11, 3)
+size(cdfs)
+# output
+(3, 1, 11)
+```
+```jldoctest
+cdfs = pcvct.generateSobolCDFs(7, 5; n_matrices=2)
+size(cdfs)
+# output
+(5, 2, 7)
+```
+"""
 function generateSobolCDFs(n::Int, d::Int; n_matrices::Int=1, T::Type=Float64, randomization::RandomizationMethod=NoRand(), skip_start::Union{Missing, Bool, Int}=missing, include_one::Union{Missing, Bool}=missing)
     s = Sobol.SobolSeq(d * n_matrices)
     if ismissing(skip_start) # default to this
@@ -694,31 +852,14 @@ end
 
 generateSobolCDFs(sobol_variation::SobolVariation, d::Int) = generateSobolCDFs(sobol_variation.n, d; n_matrices=sobol_variation.n_matrices, randomization=sobol_variation.randomization, skip_start=sobol_variation.skip_start, include_one=sobol_variation.include_one)
 
-function addVariations(sobol_variation::SobolVariation, inputs::InputFolders, evs::Vector{<:ElementaryVariation}, reference_variation_ids::VariationIDs)
-    pvs = ParsedVariations(evs)
-    d = length(pvs.config_variations) + length(pvs.rulesets_collection_variations) + length(pvs.ic_cell_variations)
+function addVariations(sobol_variation::SobolVariation, inputs::InputFolders, pv::ParsedVariations, reference_variation_ids::VariationIDs)
+    d = length(pv.sz)
     cdfs = generateSobolCDFs(sobol_variation, d) # cdfs is (d, sobol_variation.n_matrices, sobol_variation.n)
     cdfs_reshaped = reshape(cdfs, (d, sobol_variation.n_matrices * sobol_variation.n)) # reshape to (d, sobol_variation.n_matrices * sobol_variation.n) so that each column is a sobol sample
     cdfs_reshaped = cdfs_reshaped' # transpose so that each row is a sobol sample
-    if isempty(pvs.config_variations)
-        config_variation_ids = fill(reference_variation_ids.config, size(cdfs_reshaped,1))
-    else
-        config_variation_ids = cdfsToVariations(cdfs_reshaped[:,1:length(pvs.config_variations)], pvs.config_variations, prepareConfigVariationFunctions(inputs.config.id, pvs.config_variations; reference_config_variation_id=reference_variation_ids.config)...)
-    end
-    if isempty(pvs.rulesets_collection_variations)
-        rulesets_collection_variation_ids = fill(reference_variation_ids.rulesets_collection, size(cdfs_reshaped,1))
-    else
-        rulesets_collection_variation_ids = cdfsToVariations(cdfs_reshaped[:,length(pvs.config_variations)+1:end], pvs.rulesets_collection_variations, prepareRulesetsVariationFunctions(inputs.rulesets_collection.id; reference_rulesets_variation_id=reference_variation_ids.rulesets_collection)...)
-    end
-    if isempty(pvs.ic_cell_variations)
-        ic_cell_variation_ids = fill(reference_variation_ids.ic_cell, size(cdfs_reshaped,1))
-    else
-        ic_cell_variation_ids = cdfsToVariations(cdfs_reshaped[:,length(pvs.config_variations)+length(pvs.rulesets_collection_variations)+1:end], pvs.ic_cell_variations, prepareICCellVariationFunctions(inputs.ic_cell.id; reference_ic_cell_variation_id=reference_variation_ids.ic_cell)...)
-    end
-    config_variation_ids = reshape(config_variation_ids, (sobol_variation.n_matrices, sobol_variation.n))' # first, each sobol matrix variation indices goes into a row so that each column is the kth sample for each matrix; take the transpose so that each column corresponds to a matrix
-    rulesets_collection_variation_ids = reshape(rulesets_collection_variation_ids, (sobol_variation.n_matrices, sobol_variation.n))'
-    ic_cell_variation_ids = reshape(ic_cell_variation_ids, (sobol_variation.n_matrices, sobol_variation.n))'
-    return config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids, cdfs, pvs
+    cvis, rvis, ivis = [addLocationCDFVariations(inputs, pv, reference_variation_ids, location, cdfs_reshaped) for location in [:config, :rulesets_collection, :ic_cell]] .|>
+        x -> reshape(x, (sobol_variation.n_matrices, sobol_variation.n))' # first, each sobol matrix variation indices goes into a row so that each column is the kth sample for each matrix; take the transpose so that each column corresponds to a matrix
+    return cvis, rvis, ivis, cdfs
 end
 
 ################## Random Balance Design Sampling Functions ##################
@@ -796,42 +937,25 @@ function createSortedRBDMatrix(variation_ids::Vector{Int}, S::AbstractMatrix{Flo
     return variations_matrix
 end
 
-function addVariations(rbd_variation::RBDVariation, inputs::InputFolders, evs::Vector{<:ElementaryVariation}, reference_variation_ids::VariationIDs)
-    pvs = ParsedVariations(evs)
-    d = length(pvs.config_variations) + length(pvs.rulesets_collection_variations) + length(pvs.ic_cell_variations)
+function addVariations(rbd_variation::RBDVariation, inputs::InputFolders, pv::ParsedVariations, reference_variation_ids::VariationIDs)
+    d = length(pv.sz)
     cdfs, S = generateRBDCDFs(rbd_variation, d)
-    if isempty(pvs.config_variations)
-        config_variation_ids = fill(reference_variation_ids.config, size(cdfs,1))
-    else
-        config_variation_ids = cdfsToVariations(cdfs[:,1:length(pvs.config_variations)], pvs.config_variations, prepareConfigVariationFunctions(inputs.config.id, pvs.config_variations; reference_config_variation_id=reference_variation_ids.config)...)
-    end
-    if isempty(pvs.rulesets_collection_variations)
-        rulesets_collection_variation_ids = fill(reference_variation_ids.rulesets_collection, size(cdfs,1))
-    else
-        rulesets_collection_variation_ids = cdfsToVariations(cdfs[:,length(pvs.config_variations)+1:end], pvs.rulesets_collection_variations, prepareRulesetsVariationFunctions(inputs.rulesets_collection.id; reference_rulesets_variation_id=reference_variation_ids.rulesets_collection)...)
-    end
-    if isempty(pvs.ic_cell_variations)
-        ic_cell_variation_ids = fill(reference_variation_ids.ic_cell, size(cdfs,1))
-    else
-        ic_cell_variation_ids = cdfsToVariations(cdfs[:,length(pvs.config_variations)+length(pvs.rulesets_collection_variations)+1:end], pvs.ic_cell_variations, prepareICCellVariationFunctions(inputs.ic_cell.id; reference_ic_cell_variation_id=reference_variation_ids.ic_cell)...)
-    end
-    config_variations_matrix = createSortedRBDMatrix(config_variation_ids, S)
-    rulesets_variations_matrix = createSortedRBDMatrix(rulesets_collection_variation_ids, S)
-    ic_cell_variations_matrix = createSortedRBDMatrix(ic_cell_variation_ids, S)
-    return config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids, config_variations_matrix, rulesets_variations_matrix, ic_cell_variations_matrix
+    config_vids, rules_vids, ic_cell_vids = [addLocationCDFVariations(inputs, pv, reference_variation_ids, location, cdfs) for location in [:config, :rulesets_collection, :ic_cell]]
+    config_var_matrix, rules_var_matrix, ic_cell_var_matrix = [createSortedRBDMatrix(vids, S) for vids in [config_vids, rules_vids, ic_cell_vids]]
+    return config_vids, rules_vids, ic_cell_vids, config_var_matrix, rules_var_matrix, ic_cell_var_matrix
 end
 
 ################## Sampling Helper Functions ##################
 
-function cdfsToVariations(cdfs::AbstractMatrix{Float64}, evs::Vector{<:ElementaryVariation}, addColumnsByPathsFn::Function, prepareAddNewFn::Function, addRowFn::Function)
+function cdfsToVariations(cdfs::AbstractMatrix{Float64}, evs::Vector{<:ElementaryVariation}, addColumnsByPathsFn::Function, prepareAddNewFn::Function, addRowFn::Function, ev_dims::AbstractVector{Int}=1:length(evs))
+    static_values, table_features = setUpColumns(evs, addColumnsByPathsFn, prepareAddNewFn)
+
     n = size(cdfs, 1)
     new_values = []
-    for (i, ev) in enumerate(evs)
-        new_value = _values(ev, cdfs[:,i]) # ok, all the new values for the given parameter
+    for (ev, col_ind) in zip(evs, ev_dims)
+        new_value = _values(ev, cdfs[:,col_ind]) # ok, all the new values for the given parameter
         push!(new_values, new_value)
     end
-
-    static_values, table_features = setUpColumns(evs, addColumnsByPathsFn, prepareAddNewFn)
 
     variation_ids = zeros(Int, n)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ include("./test-project/VCT/PrintHelpers.jl")
     include("./test-project/VCT/GenerateData.jl") # this file is created by CreateProjectTests.jl
 
     include("./test-project/VCT/RunnerTests.jl")
+    include("./test-project/VCT/UserAPITests.jl")
     include("./test-project/VCT/ImportTests.jl")
     include("./test-project/VCT/PrunerTests.jl")
     include("./test-project/VCT/ConfigurationTests.jl")

--- a/test/test-project/VCT/ConfigurationTests.jl
+++ b/test/test-project/VCT/ConfigurationTests.jl
@@ -10,7 +10,7 @@ inputs = InputFolders(config_folder, custom_code_folder; rulesets_collection=rul
 
 n_replicates = 2
 
-path_to_xml = "$(path_to_data_folder)/inputs/configs/$(config_folder)/PhysiCell_settings.xml"
+path_to_xml = joinpath("test-project", "data", "inputs", "configs", config_folder, "PhysiCell_settings.xml")
 
 cell_type = "default"
 

--- a/test/test-project/VCT/CreateProjectTests.jl
+++ b/test/test-project/VCT/CreateProjectTests.jl
@@ -6,33 +6,3 @@ hashBorderPrint(str)
 
 project_dir = "./test-project"
 createProject(project_dir)
-
-path_to_data_folder = joinpath(".", "test-project", "data")
-
-# set up ic cell stuff
-mkdir(joinpath(path_to_data_folder, "inputs", "ics", "cells", "1_xml"))
-xml_doc = XMLDocument()
-xml_root = create_root(xml_doc, "ic_cells")
-
-e_patches = new_child(xml_root, "cell_patches")
-set_attribute(e_patches, "name", "default")
-
-e_discs = new_child(e_patches, "patch_collection")
-set_attribute(e_discs, "type", "disc")
-e_patch = new_child(e_discs, "patch")
-set_attribute(e_patch, "ID", "1")
-for (name, value) in [("x0", "0.0"), ("y0", "0.0"), ("z0", "0.0"), ("radius", "10.0"), ("number", "50")]
-    e = new_child(e_patch, name)
-    set_content(e, value)
-end
-
-e_annuli = new_child(e_patches, "patch_collection")
-set_attribute(e_annuli, "type", "annulus")
-e_patch = new_child(e_annuli, "patch")
-set_attribute(e_patch, "ID", "1")
-for (name, value) in [("x0", "50.0"), ("y0", "50.0"), ("z0", "0.0"), ("inner_radius", "10.0"), ("outer_radius", "200.0"), ("number", "50")]
-    e = new_child(e_patch, name)
-    set_content(e, value)
-end
-
-save_file(xml_doc, joinpath(path_to_data_folder, "inputs", "ics", "cells", "1_xml", "cells.xml"))

--- a/test/test-project/VCT/LoaderTests.jl
+++ b/test/test-project/VCT/LoaderTests.jl
@@ -15,7 +15,7 @@ push!(discrete_variations, DiscreteVariation(["save","SVG","interval"], 6.0))
 
 out = run(inputs, discrete_variations; use_previous=false)
 @test out.trial isa Simulation
-sequence = pcvct.PhysiCellSequence(joinpath(path_to_data_folder, "outputs", "simulations", string(out.trial.id), "output"); include_cells=true, include_substrates=true)
+sequence = pcvct.PhysiCellSequence(joinpath("test-project", "data", "outputs", "simulations", string(out.trial.id), "output"); include_cells=true, include_substrates=true)
 
 seq_dict = getCellDataSequence(sequence, "elapsed_time_in_phase"; include_dead=true)
 

--- a/test/test-project/VCT/UserAPITests.jl
+++ b/test/test-project/VCT/UserAPITests.jl
@@ -1,0 +1,26 @@
+filename = @__FILE__
+filename = split(filename, "/") |> last
+str = "TESTING WITH $(filename)"
+hashBorderPrint(str)
+
+config_folder = "0_template"
+rulesets_collection_folder = "0_template"
+custom_code_folder = "0_template"
+inputs = InputFolders(config_folder, custom_code_folder; rulesets_collection=rulesets_collection_folder)
+
+method = GridVariation()
+
+dv = DiscreteVariation(["overall","max_time"], [12.0, 13.0])
+
+out = run(method, inputs, dv)
+
+method = LHSVariation(3)
+dv = UniformDistributedVariation(["overall","max_time"], 12.0, 20.0)
+reference = getSimulationIDs(out)[1] |> Simulation
+out = run(method, reference, dv)
+
+method = SobolVariation(4)
+out = run(method, reference, dv)
+
+method = pcvct.RBDVariation(5)
+out = run(method, reference, dv)

--- a/test/test-project/VCT/VariationsTests.jl
+++ b/test/test-project/VCT/VariationsTests.jl
@@ -11,6 +11,8 @@ rulesets_collection_folder = "0_template"
 ic_cell_folder = "1_xml"
 inputs = InputFolders(config_folder, custom_code_folder; rulesets_collection=rulesets_collection_folder, ic_cell=ic_cell_folder)
 
+cell_type = "default"
+
 xml_path = [pcvct.apoptosisPath(cell_type); "death_rate"]
 dv = UniformDistributedVariation(xml_path, 0.0, 1.0)
 @test_throws ErrorException pcvct._values(dv)
@@ -76,3 +78,53 @@ config_variation_ids, rulesets_collection_variation_ids, ic_cell_variation_ids =
 
 # test deprecation of ElementaryVariation
 @test_warn "`ElementaryVariation` is deprecated in favor of the more descriptive `DiscreteVariation`." ElementaryVariation(xml_path, [0.0, 1.0])
+
+# CoVariation tests
+config_folder = "0_template"
+custom_code_folder = "0_template"
+rulesets_collection_folder = "0_template"
+ic_cell_folder = "1_xml"
+inputs = InputFolders(config_folder, custom_code_folder; rulesets_collection=rulesets_collection_folder, ic_cell=ic_cell_folder)
+
+dv_max_time = DiscreteVariation(["overall", "max_time"], 12.0)
+apoptosis_rate_path = [pcvct.apoptosisPath(cell_type); "death_rate"]
+cycle_rate_path = [pcvct.cyclePath(cell_type); "phase_durations"; "duration:index:0"]
+val_1 = [0.0, 1.0]
+val_2 = [1000.0, 2000.0]
+cv = CoVariation((apoptosis_rate_path, val_1), (cycle_rate_path, val_2))
+
+sampling = createTrial(inputs, [dv_max_time, cv]; n_replicates=2)
+@test length(sampling.monad_ids) == 2
+@test length(sampling) == 4
+
+df = pcvct.simulationsTable(sampling)
+drs = df[!, Symbol("default: apop death rate")]
+pdurs = df[!, Symbol("default: duration:index:0")]
+for (dr, pdur) in zip(drs, pdurs)
+    @test (val_1.==dr) == (val_2.==pdur) # make sure they are using the same index in both
+end
+
+max_response_path = ["hypothesis_ruleset:name:default","behavior:name:cycle entry","decreasing_signals","max_response"]
+mrs = [1.0, 2.0]
+
+x0_path = ["cell_patches:name:default", "patch_collection:type:disc", "patch:ID:1", "x0"]
+x0s = [0.0, -100.0]
+
+cv_new = CoVariation([cv.variations; DiscreteVariation(max_response_path, mrs); DiscreteVariation(x0_path, x0s)])
+sampling = createTrial(inputs, [dv_max_time, cv_new]; n_replicates=3)
+@test length(sampling.monad_ids) == 2
+@test length(sampling) == 6
+
+d_1 = Uniform(0, 1)
+d_2 = Normal(3, 0.01)
+cv = CoVariation((apoptosis_rate_path, d_1), (cycle_rate_path, d_2))
+sampling = createTrial(LHSVariation(5), inputs, cv; n_replicates=3)
+@test length(sampling.monad_ids) == 5
+@test length(sampling) == 15
+@test pcvct.location(cv) == [:config, :config]
+@test pcvct.target(cv) == [apoptosis_rate_path, cycle_rate_path]
+# @test cdf(dv, ) = 
+
+cv = CoVariation(cv.variations[1], cv.variations[2]) # CoVariation(ev1, ev2, ...)
+sampling = createTrial(SobolVariation(7), inputs, cv; n_replicates=2)
+@test length(sampling.monad_ids) == 7


### PR DESCRIPTION
- define CoVariation{T<:ElementaryVariation} <: AbstractVariation
- update createTrial and run calls to handle AbstractVariation (and thus the new CoVariation)
- createTrial can now take in a variation method as the first entry to run that kind of variation; without it, uses a GridVariation
- similarly, for run (see line up)
- new addVariations method for flexibility
- ParsedVariations now tracks `sz`, the size of each dimension of the variations fed into it
- ParsedVariations now also stores a copy of the variations fed into it
- simplify `addVariations(::GridVariation, ...)` to use new function `addLocationGridVariations`
- allow for CoVarariations when adding GridVariation
- getSimulationIDs on the `PCVCTOutput` object works
- UserAPI functions can now include an optional `AddVariationMethod` argument; without it, it uses the default `GridVariation()`
- `Base.length(::Distributed) = -1` just so these can be computed and return something identifiable
- `prepareVariationFunctions` to handle the location cases
- docstrings for `generateLHSCDFs` and `generateSobolCDFs` with tests to show the output dimensions
- docstrings for `GSASampling`, `calculateGSA!`, `MOATSampling`, `SobolSampling`
- `addVariations(::LHSVariation, ...)` refactored
- `addVariations(::SobolVariation, ...)` refactored
- `addVariations(::RBDVariation, ...)` refactored
- added `UserAPITests.jl`
- add variations and sensitivity tests for covariations
- sensitivity with CoVariation
- sensitivity post-processing in guide
- allow for DistributedVariation's to be flipped
- fix renaming col names for simulation table: pars for necr and apop were being renamed to the same thing; not include "apop"/"necr" in the col name
- generally, making `ParsedVariations` more used throughout