### PR TITLE
fix CoVariation constructor

### DIFF
--- a/src/VCTVariations.jl
+++ b/src/VCTVariations.jl
@@ -247,18 +247,16 @@ struct CoVariation{T<:ElementaryVariation} <: AbstractVariation
         end
         return new{DiscreteVariation}(variations)
     end
-    function CoVariation(ev::T) where {T<:ElementaryVariation}
-        return new{T}([ev])
-    end
-    function CoVariation(evs::Vector{T}) where {T<:ElementaryVariation}
-        if T == DistributedVariation
-            return new{T}(evs)
-        end
+    CoVariation(evs::Vector{DistributedVariation}) = return new{DistributedVariation}(evs)
+    function CoVariation(evs::Vector{<:DiscreteVariation})
         @assert (length.(evs) |> unique |> length) == 1 "All DiscreteVariations in a CoVariation must have the same length."
         return new{DiscreteVariation}(evs)
     end
-    function CoVariation(inputs::Vararg{T,N}) where {T<:ElementaryVariation,N}
-        return CoVariation(Vector{T}([inputs...]))
+    function CoVariation(inputs::Vararg{DistributedVariation,N}) where {N}
+        return CoVariation(Vector{DistributedVariation}([inputs...]))
+    end
+    function CoVariation(inputs::Vararg{<:DiscreteVariation,N}) where {N}
+        return CoVariation(Vector{DiscreteVariation}([inputs...]))
     end
 end
 

--- a/test/test-project/VCT/VariationsTests.jl
+++ b/test/test-project/VCT/VariationsTests.jl
@@ -111,6 +111,7 @@ x0_path = ["cell_patches:name:default", "patch_collection:type:disc", "patch:ID:
 x0s = [0.0, -100.0]
 
 cv_new = CoVariation([cv.variations; DiscreteVariation(max_response_path, mrs); DiscreteVariation(x0_path, x0s)])
+cv_test = CoVariation(cv_new.variations...)
 sampling = createTrial(inputs, [dv_max_time, cv_new]; n_replicates=3)
 @test length(sampling.monad_ids) == 2
 @test length(sampling) == 6


### PR DESCRIPTION
needs to accept vararg of `DiscreteVariation`s with possibly different datatypes (Int, Float64, etc)