### PR TITLE
fix error handling of sims; handle deletion on NFS

### DIFF
--- a/test/test-project/VCT/HPCTests.jl
+++ b/test/test-project/VCT/HPCTests.jl
@@ -1,3 +1,5 @@
+using Dates
+
 filename = @__FILE__
 filename = split(filename, "/") |> last
 str = "TESTING WITH $(filename)"
@@ -6,8 +8,9 @@ hashBorderPrint(str)
 pcvct.useHPC()
 
 simulation = Simulation(1)
+monad = Monad(simulation)
 
-cmd_local = pcvct.prepareSimulationCommand(simulation, missing, true, false)
+cmd_local = pcvct.prepareSimulationCommand(simulation, monad.id, true, false)
 cmd_local_str = string(cmd_local)
 cmd_local_str = strip(cmd_local_str, '`')
 cmd_hpc = pcvct.prepareHPCCommand(cmd_local, simulation.id)
@@ -19,4 +22,38 @@ cmd_string = strip(cmd_string, '`')
 @test contains(cmd_string, "--wrap=$(cmd_local_str)")
 @test contains(cmd_string, "--wait")
 
+# test prep of command
+# gh actions runners not expected to have `sbatch` installed
+@test_throws Base.IOError pcvct.SimulationProcess(simulation)
+
+# test hpc removal of file that does not exist
+@test isnothing(pcvct.rm_hpc_safe("not_a_file.txt"))
+
+# test hpc removal of file that does exist
+current_time = Dates.now()
+threshold_seconds = 15
+end_of_day = DateTime(Dates.year(current_time), Dates.month(current_time), Dates.day(current_time), 23, 59, 59)
+threshold_time = end_of_day - Second(threshold_seconds)
+is_about_to_be_next_day = current_time >= threshold_time
+if is_about_to_be_next_day
+    # if it's about to be the next day, wait until it is the next day
+    sleep(threshold_seconds + 1)
+end
+path_to_dummy_file = joinpath(pcvct.data_dir, "test.txt")
+open(path_to_dummy_file, "w") do f
+    write(f, "test")
+end
+pcvct.rm_hpc_safe(path_to_dummy_file)
+@test joinpath(pcvct.data_dir, ".trash", "data-$(Dates.format(now(), "yymmdd"))", "test.txt") |> isfile
+
+# test hpc removal of file with same name
+path_to_dummy_file = joinpath(pcvct.data_dir, "test.txt")
+open(path_to_dummy_file, "w") do f
+    write(f, "test")
+end
+pcvct.rm_hpc_safe(path_to_dummy_file)
+@test joinpath(pcvct.data_dir, ".trash", "data-$(Dates.format(now(), "yymmdd"))", "test-1.txt") |> isfile
+
+# revert back to not using HPC for remainder of tests
 pcvct.useHPC(false)
+

--- a/test/test-project/VCT/RunnerTests.jl
+++ b/test/test-project/VCT/RunnerTests.jl
@@ -103,3 +103,8 @@ out = run(trial; force_recompile=false)
 hashBorderPrint("SUCCESSFULLY RAN TRIAL!")
 
 @test_warn "`runAbstractTrial` is deprecated. Use `run` instead." runAbstractTrial(trial; force_recompile=false)
+
+# run a sim that will produce an error
+dv = DiscreteVariation(["hypothesis_ruleset:name:default", "behavior:name:cycle entry", "decreasing_signals", "max_response"], 100.0)
+out = run(inputs, dv)
+@test out.n_success == 0


### PR DESCRIPTION
- referenced undefined vars causing hangups after erroring
- also created `SimulationProcess` struct to more elegantly handle pushing to `simulation_tasks` vector
- test sim with error
- test `SimulationProcess` as if running on HPC
- when running on hpc, rather than delete, move them to data_dir/.trash
- this avoids the issue of NFS not being able to delete files that are
  open on another node, which could lead to hangups or errors
- within .trash, make directories day-specific, e.g. .trash/data-250208
    - this makes them a bit easier to search through if the user wants to
- also add integer suffixes counting the duplicate file/folder names to avoid
  overwriting files which again will cause NFS issues