### PR TITLE
inputs.toml to data/inputs/inputs.toml

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,6 +26,7 @@ makedocs(;
             "Sensitivity analysis" => "man/sensitivity_analysis.md",
             "Analyzing output" => "man/analyzing_output.md",
             "Developer guide" => "man/developer_guide.md",
+            "Project configuration" => "man/project_configuration.md",
             "Index" => "man/index.md",
         ],
         "Documentation" => map(

--- a/docs/src/man/project_configuration.md
+++ b/docs/src/man/project_configuration.md
@@ -1,0 +1,40 @@
+# Project configuration
+
+The `inputs.toml` file is used to configure the inputs for the project.
+It is located in the `inputs` directory within the project data directory.
+
+## TOML-defined structure
+Each section of the `inputs.toml` file defines one of the input "locations" in the project.
+An example of the structure is as follows:
+
+```toml
+[config]
+required = true
+varied = true
+basename = "PhysiCell_settings.xml"
+```
+
+Upon initialization of the model manager, i.e., calling `initializeModelManager()`, the `inputs.toml` file is parsed and each entry (`config` is shown above) has four features stored:
+- `required`: A boolean indicating if the location is required for the model to run.
+- `basename`: The base name of the file to be used for the location.
+- `varied`: A boolean indicating if the location can vary between different model runs.
+- `path_from_inputs`: The path to the location relative to the `inputs` directory.
+
+### `required`
+This field is necessary and must either be `true` or `false`.
+If `true`, an `InputsFolder` object cannot be created without this location.
+
+### `basename`
+This field enforces the name of the file to be used for the location.
+A vector can be supplied of names in the order to look for the files in cases when multiple files are acceptable.
+This field is necessary if `varied` is `true`, but can be omitted if `varied` is `false`.
+
+### `varied`
+This field is necessary and must either be `true`, `false`, or a vector of Booleans matching the length of the `basename` vector.
+If `true`, the location can be varied and the necessary databases and folders are created to support this.
+
+### `path_from_inputs`
+This optional field sets the path to the location relative to the `inputs` directory.
+If not provided, the path is assumed to be `inputs/<dict_name>s`.
+For example, the `config` section above would be located at `inputs/configs` (note the pluralization of the section name).
+To provide this path, use a vector of strings, e.g., `["ics", "cells"]` to define the path to the `[ic_cell]` location as `inputs/ics/cells`.

--- a/docs/src/misc/database_upgrades.md
+++ b/docs/src/misc/database_upgrades.md
@@ -4,6 +4,9 @@ Not every release will change the database structure, but when one does in a way
 The warning will link to this page and the function will wait for user input to proceed.
 Changes are listed in reverse chronological order.
 
+## to v0.0.29
+The `inputs.toml` file has been moved from `data/` to `data/inputs/`.
+
 ## to v0.0.15
 Introduce XML-based ECM initial conditions. This introduces `ic_ecm_variations`.
 Also, introduce Dirichlet initial conditions from file, which introduces the `ic_dc_id` in the database.

--- a/src/classes.jl
+++ b/src/classes.jl
@@ -57,13 +57,13 @@ Hold the information for a single input folder.
 Users should use the `InputFolders` to create and access individual `InputFolder` objects.
 
 # Fields
-- `location::Symbol`: The location of the input folder, e.g. `:config`, `:custom_code`, etc. Options are defined in `data/inputs.toml`.
+- `location::Symbol`: The location of the input folder, e.g. `:config`, `:custom_code`, etc. Options are defined in `data/inputs/inputs.toml`.
 - `id::Int`: The ID of the input folder in the database.
 - `folder::String`: The name of the input folder. It will be in `data/inputs/<path_from_inputs>`.
 - `basename::Union{String,Missing}`: The basename of the input file. This can be used to determine if the input file is varied.
-- `required::Bool`: Whether the input folder is required. This is defined in `data/inputs.toml`.
+- `required::Bool`: Whether the input folder is required. This is defined in `data/inputs/inputs.toml`.
 - `varied::Bool`: Whether the input folder is varied. This is determined by the presence of a varied basename in the input folder.
-- `path_from_inputs::String`: The path from the `data/inputs` directory to the input folder. This is defined in `data/inputs.toml`.
+- `path_from_inputs::String`: The path from the `data/inputs` directory to the input folder. This is defined in `data/inputs/inputs.toml`.
 """
 struct InputFolder
     location::Symbol
@@ -124,7 +124,7 @@ end
 Consolidate the folder information for a simulation/monad/sampling.
 
 Pass the folder names within the `inputs/<path_from_inputs>` directory to create an `InputFolders` object.
-The `path_from_inputs` is defined in the `data/inputs.toml` file for each.
+The `path_from_inputs` is defined in the `data/inputs/inputs.toml` file for each.
 It is possible to acces the [`InputFolder`](@ref) values using index notation, e.g. `input_folders[:config]`.
 
 Several constructors exist:
@@ -133,7 +133,7 @@ Several constructors exist:
 InputFolders(; config="default", custom_codes="default", rulesets_collection="default")
 ```
 2. Pass in the required inputs as arguments and the optional inputs as keyword arguments. The required folders must be passed in alphabetical order.
-Refer to the names defined in `data/inputs.toml` to see this order. Omitted optional folders are assumed to be \"\", i.e. those inputs are unused.
+Refer to the names defined in `data/inputs/inputs.toml` to see this order. Omitted optional folders are assumed to be \"\", i.e. those inputs are unused.
 ```julia
 config_folder = "default"
 custom_code_folder = "default"
@@ -142,7 +142,7 @@ InputFolders(config_folder, custom_code_folder; ic_cell=ic_cell_folder)
 ```
 
 # Fields
-- `input_folders::NamedTuple`: The input locations defined in `data/inputs.toml` define the keys. The values are [`InputFolder`](@ref)s.
+- `input_folders::NamedTuple`: The input locations defined in `data/inputs/inputs.toml` define the keys. The values are [`InputFolder`](@ref)s.
 """
 struct InputFolders
     input_folders::NamedTuple
@@ -169,7 +169,7 @@ function InputFolders(args...; kwargs...) end
 """
     createSimpleInputFolders()
 
-Creates a simple method for creating `InputFolders` objects at module initialization based on `data/inputs.toml`.
+Creates a simple method for creating `InputFolders` objects at module initialization based on `data/inputs/inputs.toml`.
 
 The required inputs are sorted alphabetically and used as the positional arguments.
 The optional inputs are used as keyword arguments with a default value of `\"\"`, indicating they are unused.

--- a/src/creation.jl
+++ b/src/creation.jl
@@ -123,11 +123,9 @@ function setUpInputs(data_dir::String, physicell_dir::String, template_as_defaul
         return
     end
 
-    mkpath(data_dir)
-    createInputsTOMLTemplate(joinpath(data_dir, "inputs.toml"))
-
     inputs_dir = joinpath(data_dir, "inputs")
     mkpath(inputs_dir)
+    createInputsTOMLTemplate(joinpath(inputs_dir, "inputs.toml"))
 
     mkpath(joinpath(inputs_dir, "configs"))
     mkpath(joinpath(inputs_dir, "custom_codes"))

--- a/src/deletion.jl
+++ b/src/deletion.jl
@@ -295,7 +295,7 @@ function resetDatabase(; force_reset::Bool=false, force_continue::Bool=false)
     end
 
     rm_hpc_safe("$(centralDB().file)"; force=true)
-    initializeDatabase("$(centralDB().file)")
+    initializeDatabase()
     return nothing
 end
 

--- a/src/pcvct.jl
+++ b/src/pcvct.jl
@@ -105,29 +105,30 @@ If no arguments are provided, it assumes that the PhysiCell and data directories
 - `path_to_data::AbstractString`: Path to the data directory as either an absolute or relative path.
 """
 function initializeModelManager(path_to_physicell::AbstractString, path_to_data::AbstractString; auto_upgrade::Bool=false)
+    global pcvct_globals
     #! print big logo of PCVCT here
     println(pcvctLogo())
     println("----------INITIALIZING----------")
     pcvct_globals.physicell_dir = abspath(path_to_physicell)
     pcvct_globals.data_dir = abspath(path_to_data)
+    pcvct_globals.db = SQLite.DB(joinpath(dataDir(), "vct.db"))
+    #! start with pcvct version info
+    if !resolvePCVCTVersion(auto_upgrade)
+        println("Could not successfully upgrade database. Please check the logs for more information.")
+        return false
+    end
+    println(rpad("pcvct version:", 25, ' ') * string(pcvctVersion()))
     println(rpad("Path to PhysiCell:", 25, ' ') * physicellDir())
     println(rpad("Path to data:", 25, ' ') * dataDir())
-    success = parseProjectInputsConfigurationFile()
-    if !success
-        println("Project configuration file parsing failed.")
-        return
-    end
-    println(rpad("Path to inputs.toml:", 25, ' ') * joinpath(dataDir(), "inputs.toml"))
-    path_to_database = joinpath(dataDir(), "vct.db")
-    success = initializeDatabase(path_to_database; auto_upgrade=auto_upgrade)
-    println(rpad("Path to database:", 25, ' ') * path_to_database)
+    println(rpad("Path to database:", 25, ' ') * centralDB().file)
+    println(rpad("Path to inputs.toml:", 25, ' ') * pathToInputsConfig())
+    success = initializeDatabase()
     if !success
         pcvct_globals.db = SQLite.DB()
         println("Database initialization failed.")
         return
     end
     println(rpad("PhysiCell version:", 25, ' ') * physicellInfo())
-    println(rpad("pcvct version:", 25, ' ') * string(pcvctVersion()))
     println(rpad("Compiler:", 25, ' ') * pcvct_globals.physicell_compiler)
     println(rpad("Running on HPC:", 25, ' ') * string(pcvct_globals.run_on_hpc))
     println(rpad("Max parallel sims:", 25, ' ') * string(pcvct_globals.max_number_of_parallel_simulations))

--- a/src/pcvct_version.jl
+++ b/src/pcvct_version.jl
@@ -17,44 +17,33 @@ function pcvctVersion()
 end
 
 """
-    pcvctDBVersion(is_new_db::Bool)
+    pcvctDBVersion()
 
 Returns the version of the pcvct database. If the database does not exist, it creates a new one with the current pcvct version.
 """
-function pcvctDBVersion(is_new_db::Bool)
+function pcvctDBVersion()
     #! check if versions table exists
     table_name = "pcvct_version"
-    versions_exists = DBInterface.execute(centralDB(), "SELECT name FROM sqlite_master WHERE type='table' AND name='$(table_name)';") |> DataFrame |> x -> (length(x.name)==1)
+    versions_exists = DBInterface.execute(centralDB(), "SELECT name FROM sqlite_master WHERE type='table' AND name='$(table_name)';") |> DataFrame |> x -> (length(x.name) == 1)
     if !versions_exists
-        createPCVCTVersionTable(is_new_db)
+        DBInterface.execute(centralDB(), "CREATE TABLE IF NOT EXISTS $(table_name) (version TEXT PRIMARY KEY);")
+        DBInterface.execute(centralDB(), "INSERT INTO $(table_name) (version) VALUES ('$(pcvctVersion())');")
     end
+
     return queryToDataFrame("SELECT * FROM $(table_name);") |> x -> x.version[1] |> VersionNumber
 end
 
 """
-    createPCVCTVersionTable(is_new_db::Bool)
-
-Creates the pcvct_version table in the database if it does not exist.
-If is_new_db is true, it inserts the current pcvct version into the table.
-"""
-function createPCVCTVersionTable(is_new_db::Bool)
-    table_name = "pcvct_version"
-    DBInterface.execute(centralDB(), "CREATE TABLE IF NOT EXISTS $(table_name) (version TEXT PRIMARY KEY);")
-    version = is_new_db ? pcvctVersion() : v"0.0.0"
-    DBInterface.execute(centralDB(), "INSERT INTO $(table_name) (version) VALUES ('$version');")
-end
-
-"""
-    resolvePCVCTVersion(is_new_db::Bool, auto_upgrade::Bool)
+    resolvePCVCTVersion(auto_upgrade::Bool)
 
 Resolve differences between the pcvct version and the database version.
 If the pcvct version is lower than the database version, it returns false (upgrade your version of pcvct to match what was already used for the database).
 If the pcvct version is equal to the database version, it returns true.
 If the pcvct version is higher than the database version, it upgrades the database to the current pcvct version and returns true.
 """
-function resolvePCVCTVersion(is_new_db::Bool, auto_upgrade::Bool)
+function resolvePCVCTVersion(auto_upgrade::Bool)
     pcvct_version = pcvctVersion()
-    pcvct_db_version = pcvctDBVersion(is_new_db)
+    pcvct_db_version = pcvctDBVersion()
 
     if pcvct_version < pcvct_db_version
         msg = """

--- a/src/project_configuration.jl
+++ b/src/project_configuration.jl
@@ -59,24 +59,24 @@ Parse the `inputs.toml` file in the data directory and create a global [`Project
 function parseProjectInputsConfigurationFile()
     inputs_dict_temp = Dict{String, Any}()
     try
-        inputs_dict_temp = TOML.parsefile(joinpath(dataDir(), "inputs.toml"))
+        inputs_dict_temp = pathToInputsConfig() |> TOML.parsefile
     catch e
         println("Error parsing project configuration file: ", e)
         return false
     end
     for (location, location_dict) in pairs(inputs_dict_temp)
+        @assert haskey(location_dict, "required") "inputs.toml: $(location): required must be defined."
+        @assert haskey(location_dict, "varied") "inputs.toml: $(location): varied must be defined."
         if !("path_from_inputs" in keys(location_dict))
             location_dict["path_from_inputs"] = tableName(location)
         else
             location_dict["path_from_inputs"] = location_dict["path_from_inputs"] .|> sanitizePathElement |> joinpath
         end
         if !("basename" in keys(location_dict))
+            @assert location_dict["varied"] isa Bool && (!location_dict["varied"]) "inputs.toml: $(location): basename must be defined if varied is true."
             location_dict["basename"] = missing
-        else
-            @assert haskey(location_dict, "varied") "inputs.toml: $(location): basename must be accompanied by varied."
-            if location_dict["varied"] isa Vector
-                @assert location_dict["basename"] isa Vector && length(location_dict["varied"]) == length(location_dict["basename"]) "inputs.toml: $(location): varied must be a Bool or a Vector of the same length as basename."
-            end
+        elseif location_dict["varied"] isa Vector
+            @assert location_dict["basename"] isa Vector && length(location_dict["varied"]) == length(location_dict["basename"]) "inputs.toml: $(location): varied must be a Bool or a Vector of the same length as basename."
         end
     end
     pcvct_globals.inputs_dict = [Symbol(location) => location_dict for (location, location_dict) in pairs(inputs_dict_temp)] |> Dict{Symbol, Any}
@@ -200,6 +200,13 @@ function folderIsVaried(location::Symbol, folder::String)
     end
     throw(ErrorException("No basename files found in folder $(path_to_folder). Must be one of $(basenames)"))
 end
+
+"""
+    pathToInputsConfig()
+
+Return the path to the `inputs.toml` file in the `inputs` directory.
+"""
+pathToInputsConfig() = joinpath(dataDir(), "inputs", "inputs.toml")
 
 """
     createInputsTOMLTemplate(path_to_toml::String)

--- a/src/up.jl
+++ b/src/up.jl
@@ -12,7 +12,7 @@ Otherwise, it will prompt the user for confirmation before large upgrades.
 """
 function upgradePCVCT(from_version::VersionNumber, to_version::VersionNumber, auto_upgrade::Bool)
     println("Upgrading pcvct from version $(from_version) to $(to_version)...")
-    milestone_versions = [v"0.0.1", v"0.0.3", v"0.0.10", v"0.0.11", v"0.0.13", v"0.0.15", v"0.0.16", v"0.0.25"]
+    milestone_versions = [v"0.0.1", v"0.0.3", v"0.0.10", v"0.0.11", v"0.0.13", v"0.0.15", v"0.0.16", v"0.0.25", v"0.0.29"]
     next_milestone_inds = findall(x -> from_version < x, milestone_versions) #! this could be simplified to take advantage of this list being sorted, but who cares? It's already so fast
     next_milestones = milestone_versions[next_milestone_inds]
     success = true
@@ -402,6 +402,35 @@ function upgradeToV0_0_25(::Bool)
                 mv(temp_dst, dst)
             end
         end
+    end
+    return true
+end
+
+function upgradeToV0_0_29(auto_upgrade::Bool)
+    warning_msg = """
+    \t- Upgrading to version 0.0.29...
+    \nWARNING: Upgrading to version 0.0.29 will change the location of the `inputs.toml` file.
+    See info at https://drbergman.github.io/pcvct/stable/misc/database_upgrades/
+
+    ------IF ANOTHER INSTANCE OF PCVCT IS USING THIS DATABASE, PLEASE CLOSE IT BEFORE PROCEEDING.------
+
+    Continue upgrading to version 0.0.29? (y/n):
+    """
+    println(warning_msg)
+    response = auto_upgrade ? "y" : readline()
+    if response != "y"
+        println("Upgrade to version 0.0.29 aborted.")
+        return false
+    end
+    println("\t- Upgrading to version 0.0.29...")
+    old_file_path = joinpath(dataDir(), "inputs.toml")
+    new_file_path = pathToInputsConfig()
+    @assert isfile(old_file_path) "The inputs.toml file is missing. Please create it before upgrading to version 0.0.29."
+    @assert isdir(joinpath(dataDir(), "inputs")) "The inputs directory is missing. Please create it before upgrading to version 0.0.29."
+    if isfile(new_file_path)
+        println("The inputs.toml file is already in the inputs directory. No need to move it.")
+    else
+        mv(old_file_path, new_file_path)
     end
     return true
 end

--- a/test/test-scripts/DatabaseTests.jl
+++ b/test/test-scripts/DatabaseTests.jl
@@ -18,7 +18,7 @@ custom_code_src_folder =  joinpath(pcvct.dataDir(), "inputs", "custom_codes")
 custom_code_dest_folder = joinpath(pcvct.dataDir(), "inputs", "custom_codes_")
 mv(custom_code_src_folder, custom_code_dest_folder)
 
-@test pcvct.createSchema(false) == false
+@test pcvct.createSchema() == false
 
 mv(config_dest_folder, config_src_folder)
 mv(custom_code_dest_folder, custom_code_src_folder)
@@ -62,4 +62,4 @@ mkdir(path_to_bad_folder)
 @test pcvct.reinitializeDatabase() == false
 
 rm(path_to_bad_folder; force=true, recursive=true)
-@test pcvct.initializeDatabase(pcvct.centralDB().file) == true
+@test pcvct.initializeDatabase() == true


### PR DESCRIPTION
- revamp of initializeModelManager to reorder things more coherently and support updates to other things than just the database.
- add project configuration to docs
- significantly reduce passing around of variables between functions at initialization; makes things easier to read and understand; also much cleaner
- asser varied is required for inputs.toml