### PR TITLE
fix librr path check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,8 +80,8 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: echo "C:\\hostedtoolcache\\windows\\julia\\${{ matrix.julia-version }}\\${{ matrix.arch }}\\bin" >> $GITHUB_PATH
 
-    - name: Set environment variable PHYSICELL_CPP
-      run: echo "PHYSICELL_CPP=${{ matrix.compiler }}" >> $GITHUB_ENV
+    # - name: Set environment variable PHYSICELL_CPP
+    #   run: echo "PHYSICELL_CPP=${{ matrix.compiler }}" >> $GITHUB_ENV
 
     - uses: julia-actions/cache@v2
 
@@ -109,9 +109,11 @@ jobs:
         PCMM_NUM_PARALLEL_SIMS: 8
         PCMM_IMAGEMAGICK_PATH: not/the/real/path/just/for/testing
         PCMM_FFMPEG_PATH: another/not/real/path/just/for/testing
-        PHYSICELL_CPP: ${{ matrix.compiler }} # maybe necessary for windows??
+        PHYSICELL_CPP: ${{ matrix.compiler }}
         PCMM_PUBLIC_REPO_AUTH: ${{ secrets.PUBLIC_REPO_AUTH }}
         JULIA_DEBUG: PhysiCellModelManager
+        DYLD_LIBRARY_PATH: ./addons/libRoadrunner/roadrunner/lib # used on macos-latest (should work)
+        LD_LIBRARY_PATH: ./addons/libRoadrunner/roadrunner/lib/testing/path # used otherwise (this path should fail; just for testing)
 
     - uses: julia-actions/julia-processcoverage@v1
       with:

--- a/docs/src/misc/database_upgrades.md
+++ b/docs/src/misc/database_upgrades.md
@@ -9,6 +9,8 @@ Rename the database file from `pcvct.db` to `pcmm.db` to reflect the name change
 
 ## to v0.0.30
 The `pcvct_version` table is renamed to `pcmm_version` due to the name change of the package.
+Also, check any environment variables you have set, e.g., in the `~/.zshrc` or `~/.bashrc` files, and update them to reflect the new package name.
+Any that were prefixed with `PCVCT_` should now be prefixed with `PCMM_`.
 
 ## to v0.0.29
 The `inputs.toml` file has been moved from `data/` to `data/inputs/`.

--- a/src/configuration.jl
+++ b/src/configuration.jl
@@ -401,6 +401,11 @@ function configPath(tokens::Vararg{Union{AbstractString,Integer}})
         elseif startswith(token2, "custom")
             new_token2 = token2[8:end] |> lstrip #! remove "custom:", "custom ", or "custom: " from the token
             return customDataPath(token1, new_token2)
+        elseif token1 == "save" && lowercase(token2) ∈ ["full", "svg"]
+            if lowercase(token2) == "full"
+                return fullSavePath()
+            end
+            return svgSavePath()
         elseif token1 ∈ ["user_parameter", "user_parameters"]
             return userParameterPath(token2)
         else
@@ -420,6 +425,9 @@ function configPath(tokens::Vararg{Union{AbstractString,Integer}})
 
             Alternatively, if this is a user parameter, make sure it is of the form:
               configPath("user_parameter", <parameter>)
+
+            Or if this is a save interval, use:
+              configPath("save", "full") or configPath("save", "svg")
             """
             throw(ArgumentError(msg))
         end

--- a/src/export.jl
+++ b/src/export.jl
@@ -122,9 +122,8 @@ function createExportFolder(simulation::Simulation, export_folder::AbstractStrin
     physicell_version_id = row.physicell_version_id[1]
     where_str = "WHERE physicell_version_id = (:physicell_version_id)"
     stmt_str = constructSelectQuery("physicell_versions", where_str)
-    stmt = SQLite.Stmt(centralDB(), stmt_str)
     params = (; :physicell_version_id => physicell_version_id)
-    row = stmtToDataFrame(stmt, params; is_row=true)
+    row = stmtToDataFrame(stmt_str, params; is_row=true)
     physicell_version = row.tag[1]
     if ismissing(physicell_version)
         physicell_version = row.commit_hash[1]

--- a/src/pcmm_version.jl
+++ b/src/pcmm_version.jl
@@ -11,7 +11,8 @@ function pcmmVersion()
         proj.version
     else
         deps = Pkg.dependencies()
-        deps[proj.dependencies["PhysiCellModelManager"]].version
+        pcmm_uuid = findfirst(kv[2].name == "PhysiCellModelManager" for kv in deps) #! kv = key-value pair
+        deps[pcmm_uuid].version
     end
     return version
 end
@@ -47,7 +48,7 @@ Returns the version from the specified table if it exists, otherwise returns not
 The `kwargs...` are passed to the `tableExists` function to check if the table exists.
 """
 function versionFromTable(table_name::String; kwargs...)
-    if !tableExists(table_name; kwargs...)
+    if !tableExists(table_name; kwargs...) #! important for helping upgrade to pcvct_version -> pcmm_version in db (can be removed at v0.2.0 or whenever we drop support for <0.30.0)
         return nothing
     end
 

--- a/src/physicell_version.jl
+++ b/src/physicell_version.jl
@@ -11,16 +11,13 @@ function resolvePhysiCellVersionID()
         tag = readlines(joinpath(physicellDir(), "VERSION.txt"))[1]
         full_tag = "$tag-download"
 
-        stmt = SQLite.Stmt(centralDB(),
-            "INSERT OR IGNORE INTO physicell_versions (commit_hash) VALUES (:full_tag) RETURNING physicell_version_id;"
-        )
+        stmt_str = "INSERT OR IGNORE INTO physicell_versions (commit_hash) VALUES (:full_tag) RETURNING physicell_version_id;"
         params = (; :full_tag => full_tag)
-        df = stmtToDataFrame(stmt, params)
+        df = stmtToDataFrame(stmt_str, params)
         if isempty(df)
             where_str = "WHERE commit_hash=(:full_tag)"
             stmt_str = constructSelectQuery("physicell_versions", where_str; selection="physicell_version_id")
-            stmt = SQLite.Stmt(centralDB(), stmt_str)
-            df = stmtToDataFrame(stmt, params; is_row=true)
+            df = stmtToDataFrame(stmt_str, params; is_row=true)
         end
         return df.physicell_version_id[1]
     end

--- a/src/project_configuration.jl
+++ b/src/project_configuration.jl
@@ -68,7 +68,7 @@ function parseProjectInputsConfigurationFile()
         @assert haskey(location_dict, "required") "inputs.toml: $(location): required must be defined."
         @assert haskey(location_dict, "varied") "inputs.toml: $(location): varied must be defined."
         if !("path_from_inputs" in keys(location_dict))
-            location_dict["path_from_inputs"] = locationTableName(location; validate=false)
+            location_dict["path_from_inputs"] = locationTableName(location)
         else
             location_dict["path_from_inputs"] = location_dict["path_from_inputs"] .|> sanitizePathElement |> joinpath
         end
@@ -86,38 +86,30 @@ function parseProjectInputsConfigurationFile()
 end
 
 """
-    locationIDName(location; validate::Bool=true)
+    locationIDName(location)
 
 Return the name of the ID column for the location (as either a String or Symbol).
-If `validate` is `true`, it checks if the location is valid and exists in the project configuration.
 
 # Examples
 ```jldoctest
-julia> PhysiCellModelManager.locationIDName(:config; validate=false)
+julia> PhysiCellModelManager.locationIDName(:config)
 "config_id"
 ```
 """
-function locationIDName(location::Union{String,Symbol}; validate::Bool=true)
-    validate && validateLocation(location)
-    return tableIDName(String(location); strip_s=false)
-end
+locationIDName(location::Union{String,Symbol}) = tableIDName(String(location); strip_s=false)
 
 """
-    locationVariationIDName(location; validate::Bool=true)
+    locationVariationIDName(location)
 
 Return the name of the variation ID column for the location (as either a String or Symbol).
-If `validate` is `true`, it checks if the location is valid and exists in the project configuration.
 
 # Examples
 ```jldoctest
-julia> PhysiCellModelManager.locationVariationIDName(:config; validate=false)
+julia> PhysiCellModelManager.locationVariationIDName(:config)
 "config_variation_id"
 ```
 """
-function locationVariationIDName(location::Union{String,Symbol}; validate::Bool=true)
-    validate && validateLocation(location)
-    return "$(location)_variation_id"
-end
+locationVariationIDName(location::Union{String,Symbol}) = "$(location)_variation_id"
 
 """
     locationIDNames()
@@ -134,49 +126,33 @@ Return the names of the variation ID columns for all varied locations.
 locationVariationIDNames() = (locationVariationIDName(loc) for loc in projectLocations().varied)
 
 """
-    locationTableName(location; validate::Bool=true)
+    locationTableName(location)
 
 Return the name of the table for the location (as either a String or Symbol).
-If `validate` is `true`, it checks if the location is valid and exists in the project configuration.
+
 # Examples
 ```jldoctest
-julia> PhysiCellModelManager.locationTableName(:config; validate=false)
+julia> PhysiCellModelManager.locationTableName(:config)
 "configs"
 ```
 """
-function locationTableName(location::Union{String,Symbol}; validate::Bool=true)
-    validate && validateLocation(location)
-    return "$(location)s"
-end
+locationTableName(location::Union{String,Symbol}) = "$(location)s"
 
 """
     variationsTableName(location)
 
 Return the name of the variations table for the location (as either a String or Symbol).
 """
-function variationsTableName(location::Union{String,Symbol})
-    validateLocation(location)
-    return "$(location)_variations"
-end
+variationsTableName(location::Union{String,Symbol}) = "$(location)_variations"
 
 """
-    validateLocation(location)
-
-Validate that the location is a valid symbol or string and exists in the project locations.
-"""
-function validateLocation(location::Union{String,Symbol})
-    @assert Symbol(location) in projectLocations().all "Location $(location) is not defined in the project configuration."
-end
-
-"""
-    locationPath(location::Symbol, folder=missing; validate::Bool=true)
+    locationPath(location::Symbol, folder=missing)
 
 Return the path to the location folder in the `inputs` directory.
 
 If `folder` is not specified, the path to the location folder is returned.
 """
-function locationPath(location::Symbol, folder=missing; validate::Bool=true)
-    validate && validateLocation(location)
+function locationPath(location::Symbol, folder=missing)
     location_dict = inputsDict()[Symbol(location)]
     path_to_locations = joinpath(dataDir(), "inputs", location_dict["path_from_inputs"])
     return ismissing(folder) ? path_to_locations : joinpath(path_to_locations, folder)

--- a/src/up.jl
+++ b/src/up.jl
@@ -44,7 +44,7 @@ Populate a target table with data from a source table, using a column mapping if
 function populateTableOnFeatureSubset(db::SQLite.DB, source_table::String, target_table::String; column_mapping::Dict{String, String}=Dict{String,String}())
     @assert tableExists(source_table; db=db) "Source table $(source_table) does not exist in the database."
     @assert tableExists(target_table; db=db) "Target table $(target_table) does not exist in the database."
-    source_columns = queryToDataFrame("PRAGMA table_info($(source_table));") |> x -> x[!, :name]
+    source_columns = tableColumns(source_table; db=db)
     target_columns = [haskey(column_mapping, c) ? column_mapping[c] : c for c in source_columns]
     @assert columnsExist(target_columns, target_table; db=db) "One or more target columns do not exist in the target table."
     insert_into_cols = "(" * join(target_columns, ",") * ")"
@@ -84,7 +84,7 @@ function upgradeToV0_0_1(::Bool)
             if isempty(df)
                 continue
             end
-            column_names = queryToDataFrame("PRAGMA table_info(rulesets_variations);"; db=db_rulesets_variations) |> x -> x[!, :name]
+            column_names = tableColumns("rulesets_variations"; db=db_rulesets_variations)
             filter!(x -> x != "rulesets_collection_variation_id", column_names)
             path_to_xml = joinpath(path_to_rulesets_collection_folder, "base_rulesets.xml")
             if !isfile(path_to_xml)

--- a/test/test-scripts/ConfigurationTests.jl
+++ b/test/test-scripts/ConfigurationTests.jl
@@ -32,6 +32,9 @@ append!(element_paths, [configPath(cell_type, token) for token in cell_type_doub
 push!(element_paths, configPath("user_parameters", "number_of_cells"))
 push!(element_paths, PhysiCellModelManager.userParametersPath("number_of_cells"))
 
+save_double_tokens = ["full", "SVG", "svg"]
+append!(element_paths, [configPath("save", token) for token in save_double_tokens])
+
     #! triple token paths
 append!(element_paths, [configPath(substrate, "Dirichlet_options", token) for token in ["xmin", "xmax", "ymin", "ymax", "zmin", "zmax"]])
 

--- a/test/test-scripts/DatabaseTests.jl
+++ b/test/test-scripts/DatabaseTests.jl
@@ -63,3 +63,8 @@ mkdir(path_to_bad_folder)
 
 rm(path_to_bad_folder; force=true, recursive=true)
 @test PhysiCellModelManager.initializeDatabase() == true
+
+# test stmtToDataFrame error
+stmt_str = "SELECT * FROM simulations WHERE simulation_id = :simulation_id;"
+params = (; :simulation_id => -1)
+@test_throws AssertionError PhysiCellModelManager.stmtToDataFrame(stmt_str, params; is_row=true)

--- a/test/test-scripts/DeletionTests.jl
+++ b/test/test-scripts/DeletionTests.jl
@@ -19,7 +19,7 @@ PhysiCellModelManager.deleteSampling(1)
 PhysiCellModelManager.deleteTrial(1)
 
 deleteSimulations(1:78; filters=Dict("config_id" => 2))
-@test_throws ArgumentError deleteSimulations(1:78; filters=Dict("bad filter; --" => 2))
+@test_throws AssertionError deleteSimulations(1:78; filters=Dict("bad filter; --" => 2))
 
 input_buffer = IOBuffer("n")
 old_stdin = stdin  #! Save the original stdin


### PR DESCRIPTION
- update upgrade docs to mention env variable name change
- tableColumns function now returns column names directly
- buildWhereClause validates that the keys in filters are columns in the table
- allow two-token configPath for save intervals
- simplify logic in `stmtToDataFrame` and other logic
- fix deps check for pcmm version (in case pcmm not a direct dep of the project, but a dep of another package)
- also remove doctest for buildWhereClause
- walk back overzealous validation of locations
- ColumnSetup struct to make adding variations clearer
- set librr env vars in CI.yml
- refactor columnsExist to allow pass in of the column names to check against