### PR TITLE
Add upgrade-path CI to guard src/up.jl across versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,7 +115,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
-        wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
+        wget https://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
         sudo apt-get install -y ./libtinfo5_6.3-2ubuntu0.1_amd64.deb
 
     - name: Run all tests

--- a/.github/workflows/UpgradeCI.yml
+++ b/.github/workflows/UpgradeCI.yml
@@ -1,0 +1,86 @@
+name: Upgrade CI
+on:
+  push:
+    branches:
+      - main
+    tags: ['*']
+  pull_request:
+  workflow_dispatch:
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  upgrade:
+    name: Upgrade ${{ matrix.source-version }} → HEAD - Julia ${{ matrix.julia-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:  # needed for julia-actions/cache to delete old caches
+      actions: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version:
+          - 'lts'
+          - '1'
+        # Source release used to generate the legacy project. The dev checkout
+        # performs the upgrade, so each entry exercises every src/up.jl milestone
+        # between the source version and HEAD. Walk this back over time to cover
+        # older migrations (eventually down to pcvct@0.0.3).
+        #   0.1.7 -> HEAD crosses 0.2.0 (par_key rewrite) + 0.3.0; this is the
+        #           oldest version a real user is currently on.
+        #   0.2.2 -> HEAD crosses only 0.3.0; isolates that hop for diagnosis.
+        source-version:
+          - '0.1.7'
+          - '0.2.2'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set fake ImageMagick/ffmpeg paths
+        run: |
+          echo "PCMM_IMAGEMAGICK_PATH=not/the/real/path/just/for/testing" >> $GITHUB_ENV
+          echo "PCMM_FFMPEG_PATH=another/not/real/path/just/for/testing" >> $GITHUB_ENV
+
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: x64
+
+      - uses: julia-actions/cache@v3
+        with:
+          cache-artifacts: true
+          cache-packages: true
+          cache-registries: false
+
+      - name: Add BergmanLabRegistry
+        run: julia -e 'import Pkg; Pkg.Registry.add("General"); Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/drbergman-lab/BergmanLabRegistry.git"))'
+
+      - name: Install libRoadRunner dependencies
+        run: |
+          sudo apt-get update
+          wget https://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
+          sudo apt-get install -y ./libtinfo5_6.3-2ubuntu0.1_amd64.deb
+
+      - uses: julia-actions/julia-buildpkg@v1
+
+      - name: Generate legacy project with source version
+        env:
+          PCMM_UPGRADE_SOURCE_VERSION: ${{ matrix.source-version }}
+          PCMM_NUM_PARALLEL_SIMS: 4
+          PHYSICELL_CPP: g++
+          PCMM_PUBLIC_REPO_AUTH: ${{ secrets.PUBLIC_REPO_AUTH }}
+          JULIA_DEBUG: PhysiCellModelManager,pcvct
+        run: julia test/upgrade/generate.jl
+
+      - name: Upgrade with dev checkout and verify
+        env:
+          PCMM_UPGRADE_SOURCE_VERSION: ${{ matrix.source-version }}
+          PHYSICELL_CPP: g++
+          PCMM_PUBLIC_REPO_AUTH: ${{ secrets.PUBLIC_REPO_AUTH }}
+          JULIA_DEBUG: PhysiCellModelManager
+        run: julia --project=. test/upgrade/verify.jl

--- a/PRD.md
+++ b/PRD.md
@@ -245,10 +245,32 @@
 **Acceptance criteria:**
 - No orphaned records after normal use.
 - `up.jl` migrations are idempotent.
+- Migrations are exercised end-to-end in CI: a project created by an older released version can be opened by a newer version with `auto_upgrade=true` without data loss (see *Upgrade-path CI* below).
 
 **Edge cases:**
 - Schema version mismatch → migrate up, never silently corrupt.
 - Database file locked by another process → error with message, not silent hang.
+
+### Sub-feature: Upgrade-path CI
+
+**One-line description:** A dedicated GitHub Actions workflow that replays real version history — generate a project with an older *released* package version, then upgrade it with a newer version — to guard `src/up.jl` against regressions.
+
+**Why a separate workflow:** the test needs two different package versions present (one to write legacy data, one to upgrade it), which cannot coexist inside a single `Pkg.test()` environment. It runs on the same triggers as `CI.yml`.
+
+**Behavioral specification:**
+- A *generation* step installs a pinned older release in an isolated environment and produces a real `data/` project (DB + simulation outputs) stamped at that older version.
+- An *upgrade + verify* step opens that same project with the **dev checkout** (`auto_upgrade=true`), which runs every `src/up.jl` milestone between the source version and dev `HEAD`, then asserts data integrity directly against the SQLite database.
+- The source version is a single parameter (a CI matrix entry) so the upgrade history can be "walked back" incrementally. The primary target is `0.1.7` → `HEAD` (the oldest version a real user is currently on; crosses the `0.2.0` par_key rewrite and `0.3.0`), with `0.2.2` → `HEAD` kept to isolate the `0.3.0` hop. Eventual target: back to the oldest installable release `pcvct@0.0.3`.
+
+**Acceptance criteria:**
+- After upgrade, `simulations` / `monads` / `samplings` row counts equal the pre-upgrade snapshot (no data loss).
+- The version table is stamped with the dev `HEAD` version.
+- Output folders referenced by surviving simulations still exist on disk.
+- The upgrade completes without error crossing each milestone in range.
+
+**Edge cases / notes:**
+- Versions `< 0.1.0` were published under the package name `pcvct` (UUID `3c374bc7…`); `≥ 0.1.0` under `PhysiCellModelManager` (UUID `7582d1aa…`). The harness derives the package name from the source version. `0.0.1`/`0.0.2` were never released, so `pcvct@0.0.3` is the floor.
+- Some milestone effects are also produced by normal `initializeDatabase` (e.g. `upgradeToV0_3_0`'s `calibrations` table), so the primary guarantee of the early hops is data preservation, not migration-specific schema deltas; the latter become testable as the source version moves back through data-transforming milestones (`upgradeToV0_2_0`, the `vct.db`→`pcmm.db` rename, etc.).
 
 ---
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PhysiCellModelManager"
 uuid = "7582d1aa-5e58-4d65-a123-4418a61a2644"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Daniel Bergman <danielrbergman@gmail.com> and contributors"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ julia> out = run(inputs, dv; n_replicates = 3) # 3 replicates per apoptosis rate
   - [ ] Bayesian optimization
   - [ ] Additional methods (MCMC, Nelder-Mead, etc.) as subtypes of `AbstractCalibrationMethod`
 - [x] Database management — SQLite schema, versioned migrations (`up.jl`), diagnostics
+  - [x] Upgrade-path CI — dedicated workflow replays version history (generate with an older release, upgrade with the dev checkout) to guard `up.jl`; see [`test/upgrade/`](test/upgrade/). Source matrix currently `0.1.7` (real users' oldest version; crosses the `0.2.0` par_key rewrite) and `0.2.2`; walks back over time toward `pcvct@0.0.3`.
 - [x] Export and pruning of simulation outputs
 - [x] Intracellular model support (custom data, rules)
 - [x] IC cell and IC ECM file management

--- a/progress.md
+++ b/progress.md
@@ -5,6 +5,42 @@
 
 ---
 
+## 2026-06-15 — Upgrade-path CI for `src/up.jl`
+
+### Motivation
+`src/up.jl` (cross-version DB/file migrations) was untested. It can't live in `Pkg.test()` because exercising a migration needs *two* package versions present: an old one to write legacy data and a new one to upgrade it. Goal: a dedicated workflow that replays real version history.
+
+### Findings that shaped the design
+- **`v0.0.1`/`v0.0.2` were never released.** Registry floor is `pcvct@0.0.3` (UUID `3c374bc7…`); the package was renamed to `PhysiCellModelManager` (UUID `7582d1aa…`) at `0.1.0`. So the harness derives the package name from the source version, and "start at v0.0.1" is impossible via `Pkg`.
+- The upgrade driver (`ModelManager.upgradePackage`) always upgrades to the runtime `pkg_version`; there is **no "stop at version X" knob**, and ModelManager is out of scope (separate repo). So "one milestone hop" is controlled by *which version performs the upgrade*, not by capping.
+- `upgradeToV0_3_0` only adds the `calibrations` table, which `initializeDatabase` also creates on every init — so that migration's effect is shadowed and not independently observable. Early hops therefore assert **data preservation**, not migration-specific deltas.
+
+### Decision: "go backwards"
+Rather than start at the oldest release and upgrade with an *intermediate released* version (which would test released code, not the repo), generate with an older release and **upgrade with the dev checkout** — this exercises the repo's actual `src/up.jl`.
+- **Concrete goal (this session):** support upgrading a **`0.1.7`** project — the version a real user (the repo owner) is currently on — to `HEAD`. `0.1.7` → `HEAD` crosses `0.2.0` (the `upgradeToV0_2_0` par_key binary rewrite) and `0.3.0`.
+- CI matrix source versions: `0.1.7` (primary) and `0.2.2` (isolates the `0.3.0` hop for diagnosis). Verified against the `v0.1.7`/`v0.2.2` tags that the generation API — `createProject`, `InputFolders(...; rulesets_collection)`, `DiscreteVariation`, `configPath` shortcuts, `createTrial(...; n_replicates)`, `run` → `PCMMOutput` — is unchanged, so one `generate.jl` covers both.
+- `verify.jl` asserts the distinguishing `par_key` column on every varied-location variations table when the `0.2.0` milestone is crossed (not produced by normal init, unlike `0.3.0`'s `calibrations` table).
+- Source version is a single parameter so we can keep walking back into the `pcvct` era, ideally to `0.0.3`.
+
+### Rejected
+- *Generate@0.0.3 → upgrade@0.0.10 (released)* — tests the released migration code, not the repo's `up.jl`; also can't reach the pre-0.0.3 functions anyway. Kept as a possible future "released-vs-released" cross-check, not the primary path.
+- *Adding a `target_version` cap to `initializeModelManager`* — would let the dev version do a single hop from old data, but requires editing ModelManager (out of scope).
+
+### Design
+New workflow `.github/workflows/UpgradeCI.yml` (same triggers as `CI.yml`; ubuntu-latest; Julia `lts` + `1`). Two isolated Julia envs under `test/upgrade/tmp/`: a generation env with the pinned old release, and the dev checkout for the upgrade. Scripts `test/upgrade/generate.jl` and `test/upgrade/verify.jl`, parameterized by `PCMM_UPGRADE_SOURCE_VERSION`. Verification reads the SQLite DB directly so it's independent of either package's API.
+
+### First CI run — caught a real bug (the harness paid off immediately)
+The very first `0.1.7` → `HEAD` run failed at the `0.2.0` milestone with `UndefVarError(:validateParsBytes)`. Root cause: `upgradeToV0_2_0` (`src/up.jl`) calls `validateParsBytes` unqualified, but the `bafb5b528` modularization moved that helper into ModelManager (`variations.jl`) and it is **not exported**. The other non-exported MM helpers `up.jl` needs were explicitly imported at the top (`using ModelManager: continueMilestoneUpgrade, populateTableOnFeatureSubset`); `validateParsBytes` was missed.
+- **Impact:** this is a real shipping bug — any user on `0.1.7` (incl. the repo owner) could not upgrade to `0.2.0+`; the migration threw and rolled back every time.
+- **Fix:** added `validateParsBytes` to that explicit import. Chose the in-repo import over exporting from ModelManager (out of scope) and to match the existing pattern in the file.
+- Only this one surfaced because it is the last statement in the migration's `try` block — everything before it resolved, so the rest of the chain is exercised.
+
+### Open questions
+- How far back can generation's API be reused? `0.2.x`→`0.3.x` should share the `createProject` / `run(sampling)` API; the `pcvct` era will likely need an older generation script.
+- Does `pcvct@0.0.3` stamp a version table the newer code can read? (Resolved only when we walk back that far.)
+
+---
+
 ## 2026-06-12 — Documentation restructure for clarity & discoverability
 
 ### Motivation

--- a/src/up.jl
+++ b/src/up.jl
@@ -1,6 +1,6 @@
 using PhysiCellXMLRules
 
-using ModelManager: continueMilestoneUpgrade, populateTableOnFeatureSubset
+using ModelManager: continueMilestoneUpgrade, populateTableOnFeatureSubset, validateParsBytes
 
 const pcmm_milestones = [v"0.0.1", v"0.0.3", v"0.0.10", v"0.0.11", v"0.0.13", v"0.0.15", v"0.0.16", v"0.0.25", v"0.0.29", v"0.0.30", v"0.1.3", v"0.2.0", v"0.3.0"]
 const upgrade_fns = Dict{VersionNumber,Function}()

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -6,3 +6,4 @@
 /test-project-download
 /pcmm_project_sans_template
 /test.out
+/upgrade/tmp

--- a/test/upgrade/README.md
+++ b/test/upgrade/README.md
@@ -1,0 +1,43 @@
+# Upgrade-path CI
+
+Tests `src/up.jl` end-to-end by replaying real version history. This cannot run
+inside `Pkg.test()` because it needs two different package versions present at
+once, so it lives in its own workflow: [`.github/workflows/UpgradeCI.yml`](../../.github/workflows/UpgradeCI.yml).
+
+## How it works
+
+Two stages, run sequentially on the same runner:
+
+1. **Generate** (`generate.jl`, plain `julia`): installs a pinned *older release*
+   in an isolated environment (`tmp/gen-env`), creates a project, and runs a
+   small sampling — producing `tmp/project/{data,PhysiCell}` with a database
+   stamped at the source version.
+2. **Upgrade + verify** (`verify.jl`, `julia --project=.`): opens that same
+   project with the **dev checkout** and `auto_upgrade=true`. This runs every
+   `src/up.jl` milestone between the source version and dev `HEAD`. Assertions
+   read the SQLite database directly (API-agnostic): row counts are preserved,
+   the version table is stamped to `HEAD`, output folders survive, and any
+   milestone-specific schema delta in range is present.
+
+The source release is the single knob `PCMM_UPGRADE_SOURCE_VERSION` (and the
+`source-version` matrix entry in the workflow). Because the **dev checkout**
+performs the upgrade, this genuinely exercises the repo's `src/up.jl`.
+
+## Why "go backwards"
+
+We generate at the release just below the latest milestone and upgrade with dev
+`HEAD`, rather than upgrading old data with an intermediate *released* version
+(which would test released code, not the repo). The source version walks back
+over time to cover older migrations:
+
+| Source | Milestones crossed to HEAD | Notes |
+|--------|----------------------------|-------|
+| `0.2.2` | `0.3.0` | Isolated single-hop; mostly a data-preservation smoke test (`upgradeToV0_3_0`'s `calibrations` table is also created by normal init, so it is not distinguishing). |
+| `0.1.7` | `0.2.0`, `0.3.0` | **Primary target — a version a real user is currently on.** Exercises the `upgradeToV0_2_0` par_key rewrite (a real data transform; verified via the `par_key` column). |
+| `pcvct@0.0.x` (future) | many | Package was named `pcvct` (< `0.1.0`); the harness derives the name from the version. Floor is `pcvct@0.0.3` (`0.0.1`/`0.0.2` were never released). The `pcvct`-era project-creation API may need an older generation script. |
+
+## Notes
+
+- `tmp/` is git-ignored; it is recreated on each generation run.
+- Running locally requires a C++ compiler (`PHYSICELL_CPP`) and network access to
+  download PhysiCell; set `PCMM_PUBLIC_REPO_AUTH` to avoid GitHub rate limits.

--- a/test/upgrade/generate.jl
+++ b/test/upgrade/generate.jl
@@ -1,0 +1,71 @@
+# Upgrade-path CI — generation stage.
+#
+# Installs a *pinned older release* of the package in an isolated environment and
+# produces a real project (`data/` + `PhysiCell/`) stamped at that older version,
+# with at least one sampling's worth of simulations on disk. A later stage opens
+# this same project with the dev checkout and runs `src/up.jl` to upgrade it.
+#
+# Driven by env var `PCMM_UPGRADE_SOURCE_VERSION` (e.g. "0.2.2"). The package name
+# is derived from the version: releases < 0.1.0 were published as `pcvct`, and
+# >= 0.1.0 as `PhysiCellModelManager`.
+#
+# This script manages its own temporary project environment, so it is launched
+# with a plain `julia generate.jl` (no `--project`).
+
+import Pkg
+
+const SOURCE_VERSION = VersionNumber(get(ENV, "PCMM_UPGRADE_SOURCE_VERSION", "0.2.2"))
+const PKG_NAME = SOURCE_VERSION < v"0.1.0" ? "pcvct" : "PhysiCellModelManager"
+
+const UPGRADE_DIR = @__DIR__
+const TMP_DIR = joinpath(UPGRADE_DIR, "tmp")
+const GEN_ENV_DIR = joinpath(TMP_DIR, "gen-env")
+const PROJECT_DIR = joinpath(TMP_DIR, "project")
+
+# Start from a clean slate so reruns are deterministic.
+isdir(TMP_DIR) && rm(TMP_DIR; recursive=true, force=true)
+mkpath(GEN_ENV_DIR)
+mkpath(TMP_DIR)
+
+println("== Upgrade CI generation ==")
+println("  source version: $(SOURCE_VERSION)")
+println("  package name:   $(PKG_NAME)")
+println("  project dir:    $(PROJECT_DIR)")
+
+# Install the pinned old release into its own environment.
+Pkg.activate(GEN_ENV_DIR)
+Pkg.add(Pkg.PackageSpec(name=PKG_NAME, version=SOURCE_VERSION))
+Pkg.instantiate()
+
+@eval using $(Symbol(PKG_NAME))
+
+# Create the project (clones PhysiCell, sets up the template inputs, initializes
+# the database at the source version) and run a small sampling so that the
+# simulations / monads / samplings tables all have rows for the upgrade to act on.
+createProject(PROJECT_DIR; template_as_default=true)
+
+inputs = InputFolders("0_template", "0_template"; rulesets_collection="0_template")
+
+# Keep the simulations tiny and deterministic: short max_time and coarse output
+# intervals so PhysiCell finishes quickly in CI. The two-valued max_time yields
+# two monads; n_replicates=2 yields four simulations under one sampling.
+const N_REPLICATES = 2
+const MAX_TIMES = [12.0, 18.0]
+const N_EXPECTED_SIMS = length(MAX_TIMES) * N_REPLICATES
+
+discrete_variations = DiscreteVariation[]
+push!(discrete_variations, DiscreteVariation(configPath("max_time"), MAX_TIMES))
+push!(discrete_variations, DiscreteVariation(configPath("full_data"), 6.0))
+push!(discrete_variations, DiscreteVariation(configPath("svg_save"), 6.0))
+
+sampling = createTrial(inputs, discrete_variations; n_replicates=N_REPLICATES)
+out = run(sampling)
+println("  ran sampling: scheduled=$(out.n_scheduled) success=$(out.n_success)")
+
+# Require the full, exact set of simulations so a partial failure here surfaces
+# as a clear generation error rather than a confusing row-count mismatch in the
+# later verify stage.
+@assert out.n_scheduled == N_EXPECTED_SIMS "Expected $(N_EXPECTED_SIMS) simulations scheduled, got $(out.n_scheduled)."
+@assert out.n_success == N_EXPECTED_SIMS "Expected $(N_EXPECTED_SIMS) simulations to succeed, got $(out.n_success)."
+
+println("== Generation complete ==")

--- a/test/upgrade/verify.jl
+++ b/test/upgrade/verify.jl
@@ -1,0 +1,136 @@
+# Upgrade-path CI — upgrade + verify stage.
+#
+# Opens the project produced by `generate.jl` with the *dev checkout* and
+# `auto_upgrade=true`, which runs every `src/up.jl` milestone between the source
+# version and dev HEAD. Then asserts data integrity directly against the SQLite
+# database (independent of either package's API).
+#
+# Launched with `julia --project=. test/upgrade/verify.jl` so that the dev
+# checkout is what performs the upgrade. NOTE: `Test` is only a test-target
+# dependency, so this script uses its own assertion helper rather than `using
+# Test` (which is unavailable under `--project=.`).
+
+using PhysiCellModelManager
+using SQLite, DataFrames
+import Pkg
+
+const SOURCE_VERSION = VersionNumber(get(ENV, "PCMM_UPGRADE_SOURCE_VERSION", "0.2.2"))
+const DEV_VERSION = Pkg.project().version
+
+const UPGRADE_DIR = @__DIR__
+const PROJECT_DIR = joinpath(UPGRADE_DIR, "tmp", "project")
+const DATA_DIR = joinpath(PROJECT_DIR, "data")
+const PHYSICELL_DIR = joinpath(PROJECT_DIR, "PhysiCell")
+
+# --- tiny assertion harness (nonzero exit on any failure) ---------------------
+const FAILURES = String[]
+function check(cond::Bool, msg::AbstractString)
+    if cond
+        println("  ✓ $(msg)")
+    else
+        println("  ✗ $(msg)")
+        push!(FAILURES, msg)
+    end
+    return cond
+end
+
+# Database file and version-table names changed across milestones:
+#   vct.db  -> pcmm.db            at v0.1.3
+#   pcvct_version -> pcmm_version at v0.0.30
+dbFile() = isfile(joinpath(DATA_DIR, "pcmm.db")) ? joinpath(DATA_DIR, "pcmm.db") :
+                                                   joinpath(DATA_DIR, "vct.db")
+
+tableExists(db, t) = !isempty(DBInterface.execute(db,
+    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='$(t)';") |> DataFrame)
+
+rowCount(db, t) = tableExists(db, t) ?
+    (DBInterface.execute(db, "SELECT COUNT(*) AS n FROM $(t);") |> DataFrame).n[1] : 0
+
+function versionTable(db)
+    for t in ("pcmm_version", "pcvct_version")
+        tableExists(db, t) && return t
+    end
+    return nothing
+end
+
+dbVersion(db) = (t = versionTable(db); isnothing(t) ? nothing :
+    VersionNumber((DBInterface.execute(db, "SELECT version FROM $(t);") |> DataFrame).version[1]))
+
+# --- snapshot the project state BEFORE the upgrade ----------------------------
+@assert isdir(PROJECT_DIR) "Generated project not found at $(PROJECT_DIR). Did generate.jl run?"
+
+pre_db = SQLite.DB(dbFile())
+pre_counts = Dict(t => rowCount(pre_db, t) for t in ("simulations", "monads", "samplings"))
+pre_version = dbVersion(pre_db)
+sim_ids = (DBInterface.execute(pre_db, "SELECT simulation_id FROM simulations;") |> DataFrame).simulation_id
+close(pre_db)
+
+println("== Pre-upgrade snapshot ==")
+println("  db version: $(pre_version)")
+println("  counts:     $(pre_counts)")
+
+# --- run the upgrade with the dev checkout ------------------------------------
+println("== Upgrading $(pre_version) -> $(DEV_VERSION) with dev checkout ==")
+upgrade_ok = initializeModelManager(PHYSICELL_DIR, DATA_DIR; auto_upgrade=true)
+
+# --- assertions ---------------------------------------------------------------
+println("== Assertions ==")
+post_db = SQLite.DB(dbFile())
+
+check(upgrade_ok, "initializeModelManager with auto_upgrade succeeded")
+check(pre_version == SOURCE_VERSION, "generation stamped the source version ($(SOURCE_VERSION))")
+check(dbVersion(post_db) == DEV_VERSION, "version bumped to dev HEAD ($(DEV_VERSION))")
+
+for t in ("simulations", "monads", "samplings")
+    check(rowCount(post_db, t) == pre_counts[t],
+        "no data loss in $(t) ($(pre_counts[t]) rows preserved)")
+end
+
+for id in sim_ids
+    check(isdir(joinpath(DATA_DIR, "outputs", "simulations", string(id))),
+        "output folder for simulation $(id) intact")
+end
+
+# Milestone-specific check: crossing v0.3.0 must leave the calibrations table.
+# (Weak on its own — initializeDatabase also creates it — but harmless.)
+if pre_version < v"0.3.0" <= DEV_VERSION
+    check(tableExists(post_db, "calibrations"), "calibrations table present (crossed v0.3.0)")
+end
+
+# Milestone-specific check: crossing v0.2.0 rewrites every varied-location
+# variations table to carry a binary `par_key` column. This genuinely proves
+# `upgradeToV0_2_0` ran (it is not produced by normal init).
+function columnExists(db, table, col)
+    info = DBInterface.execute(db, "PRAGMA table_info($(table));") |> DataFrame
+    return col in info.name
+end
+
+if pre_version < v"0.2.0" <= DEV_VERSION
+    variation_dbs = String[]
+    for (root, _, files) in walkdir(joinpath(DATA_DIR, "inputs"))
+        for f in files
+            endswith(f, "variations.db") && push!(variation_dbs, joinpath(root, f))
+        end
+    end
+    check(!isempty(variation_dbs), "found at least one variations database to check par_key")
+    for path in variation_dbs
+        vdb = SQLite.DB(path)
+        tables = (DBInterface.execute(vdb,
+            "SELECT name FROM sqlite_master WHERE type='table';") |> DataFrame).name
+        for t in filter(t -> endswith(t, "_variations"), tables)
+            check(columnExists(vdb, t, "par_key"),
+                "par_key column present in $(t) of $(relpath(path, DATA_DIR)) (crossed v0.2.0)")
+        end
+        close(vdb)
+    end
+end
+
+close(post_db)
+
+if isempty(FAILURES)
+    println("\n== All upgrade checks passed ($(SOURCE_VERSION) -> $(DEV_VERSION)) ==")
+else
+    println("\n== $(length(FAILURES)) upgrade check(s) FAILED ==")
+    foreach(m -> println("  - $(m)"), FAILURES)
+    exit(1)
+end


### PR DESCRIPTION
src/up.jl (cross-version DB/file migrations) was untested: exercising a migration needs two package versions present at once (an old one to write legacy data, a new one to upgrade it), which can't live inside Pkg.test().

Add a dedicated workflow that replays real version history. A generation stage installs a pinned older release in an isolated env and produces a real project (DB + simulation outputs) stamped at that version; an upgrade+verify stage opens it with the dev checkout (auto_upgrade=true), running every src/up.jl milestone up to HEAD, then asserts data integrity directly against SQLite (API-agnostic): row counts preserved, version bumped to HEAD, output folders intact, and milestone-specific deltas (par_key after 0.2.0).

The source release is a single matrix knob so the upgrade history can be walked back over time. Initial matrix: 0.1.7 (oldest version a real user is on; crosses the 0.2.0 par_key rewrite + 0.3.0) and 0.2.2 (isolates 0.3.0). Generation API verified against the v0.1.7/v0.2.2 tags.

New:
- .github/workflows/UpgradeCI.yml (same triggers as CI.yml; ubuntu, lts + 1)
- test/upgrade/{generate.jl,verify.jl,README.md}

Docs: PRD.md (Upgrade-path CI sub-feature), progress.md (design rationale), README.md (Implementation Status), test/.gitignore (ignore upgrade/tmp).