### PR TITLE
Support vector/range inputs in makeMovie

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -303,6 +303,7 @@
 **Behavioral specification:**
 - `makeMovie(simulation_id)` invokes `make jpeg` then `make movie` in `physicellDir()`, deletes the intermediate JPEGs, and leaves `out.mp4` in the simulation's output folder.
 - `makeMovie(T::AbstractTrial)` / `makeMovie(out::PCMMOutput)` batch this over every simulation in the trial/output.
+- `makeMovie(simulation_ids::AbstractVector{<:Integer})` (e.g. `makeMovie(4:7)`) and `makeMovie(Ts::AbstractVector{<:AbstractTrial})` (e.g. `makeMovie(Simulation.(4:7))`) batch over an explicit collection; the trial-vector form flattens to IDs via `simulationIDs`.
 - Keyword arguments `framerate`, `magick_density`, `magick_resize_x`, `magick_resize_y` forward directly to the Makefile's `FRAMERATE`, `MAGICK_DENSITY`, `MAGICK_RESIZE_X`, `MAGICK_RESIZE_Y` variables (`movie`/`jpeg` targets respectively). Each defaults to `missing`, in which case the Makefile's own default for that variable is used unchanged.
 - `magick_path`/`ffmpeg_path` locate the ImageMagick/FFmpeg executables; `verbose` prints the underlying `make` command output.
 

--- a/docs/src/man/analyzing_output.md
+++ b/docs/src/man/analyzing_output.md
@@ -241,9 +241,11 @@ component_df = rightjoin(cells_df, agent_ids, on=:ID) # join on the agent IDs, k
 [`makeMovie`](@ref) uses the PhysiCell Makefile to turn a simulation's SVG snapshots into `output/out.mp4`, deleting the intermediate JPEGs afterward. It requires ImageMagick and FFmpeg to be discoverable — on `PATH`, via `PCMM_IMAGEMAGICK_PATH`/`PCMM_FFMPEG_PATH`, or passed directly as `magick_path`/`ffmpeg_path`.
 
 ```julia
-makeMovie(1)          # simulation 1 -> output/out.mp4
-makeMovie(sampling)   # every simulation in a trial
-makeMovie(out)        # every simulation in a `run` result
+makeMovie(1)              # simulation 1 -> output/out.mp4
+makeMovie(sampling)       # every simulation in a trial
+makeMovie(out)            # every simulation in a `run` result
+makeMovie(4:7)            # a range/vector of simulation IDs
+makeMovie(Simulation.(4:7)) # a vector of trials
 ```
 
 The Makefile's own animation variables are exposed as keyword arguments. Omit any of them to keep that Makefile's default:

--- a/progress.md
+++ b/progress.md
@@ -5,6 +5,21 @@
 
 ---
 
+## 2026-07-22 — Vector/range dispatch for `makeMovie`
+
+### Motivation
+`makeMovie(4:7)` (a `UnitRange{Int}`) and `makeMovie(Simulation.(4:7))` (a `Vector{Simulation}`) both threw `MethodError` — only the scalar `Int`, single `AbstractTrial`, and `PCMMOutput` forms existed. Batching over an explicit collection of IDs or trials is a natural call and should mirror the existing `AbstractTrial` batching.
+
+### Design
+- Added `makeMovie(simulation_ids::AbstractVector{<:Integer}; kwargs...)`, reusing the "announce → loop → delegate" shape of the `AbstractTrial` method.
+- Added `makeMovie(Ts::AbstractVector{<:AbstractTrial}; kwargs...) = makeMovie(simulationIDs(Ts); kwargs...)`, flattening to IDs via `simulationIDs` (already accepts a vector of trials) so it reuses the integer-vector path.
+- Broadened the worker signature from `simulation_id::Int` to `simulation_id::Integer`: elements of `AbstractVector{<:Integer}` / the output of `simulationIDs` aren't guaranteed to be `Int`, and downstream (`trialFolder`, etc.) already accept `Integer`. Purely additive — no behavior change for existing callers.
+
+### Testing
+Extended `test/test-scripts/MovieTests.jl` (Apple branch) with `makeMovie(1:1)` and `makeMovie(Simulation.(1:1))`, each a no-op (`out.mp4` already exists) returning `nothing`.
+
+---
+
 ## 2026-07-08 — Expose Makefile animation parameters (`framerate`, `magick_density`, `magick_resize_x/y`) in `makeMovie`
 
 ### Motivation

--- a/src/movie.jl
+++ b/src/movie.jl
@@ -1,9 +1,11 @@
 export makeMovie
 
 """
-    makeMovie(simulation_id::Int; magick_path::Union{Missing,String}=simulator().path_to_magick, ffmpeg_path::Union{Missing,String}=simulator().path_to_ffmpeg)
+    makeMovie(simulation_id::Integer; magick_path::Union{Missing,String}=simulator().path_to_magick, ffmpeg_path::Union{Missing,String}=simulator().path_to_ffmpeg)
     makeMovie(T::AbstractTrial; kwargs...)
     makeMovie(out::PCMMOutput; kwargs...)
+    makeMovie(simulation_ids::AbstractVector{<:Integer}; kwargs...)
+    makeMovie(Ts::AbstractVector{<:AbstractTrial}; kwargs...)
 
 Batch make movies for each simulation identified by the input.
 
@@ -18,9 +20,11 @@ There are three ways to allow this function to find these dependencies:
   3. Set environment variables `PCMM_IMAGEMAGICK_PATH` and `PCMM_FFMPEG_PATH` before `using PhysiCellModelManager`.
 
 # Arguments
-- `simulation_id::Int`: The ID of the simulation for which to make the movie.
+- `simulation_id::Integer`: The ID of the simulation for which to make the movie.
 - `T::AbstractTrial`: Make movies for all simulations in the [`AbstractTrial`](@ref).
 - `out::PCMMOutput`: Make movies for all simulations in the output, i.e., all simulations in the completed trial.
+- `simulation_ids::AbstractVector{<:Integer}`: Make movies for each simulation ID in the collection (e.g. a range such as `4:7`).
+- `Ts::AbstractVector{<:AbstractTrial}`: Make movies for every simulation across the collection of trials (e.g. `Simulation.(4:7)`).
 
 # Keyword Arguments
 - `magick_path::Union{Missing,String}`: The path to the ImageMagick executable. If not provided, uses `simulator().path_to_magick`.
@@ -45,8 +49,12 @@ makeMovie(out) # make movies for all simulations in the output
 ```julia
 makeMovie(123; framerate=10, magick_density=48, magick_resize_x=512, magick_resize_y=512)
 ```
+```julia
+makeMovie(4:7) # make movies for simulations 4, 5, 6, and 7
+makeMovie(Simulation.(4:7)) # equivalent, passing Simulation objects
+```
 """
-function makeMovie(simulation_id::Int; magick_path::Union{Missing,String}=simulator().path_to_magick, ffmpeg_path::Union{Missing,String}=simulator().path_to_ffmpeg, verbose::Bool=false,
+function makeMovie(simulation_id::Integer; magick_path::Union{Missing,String}=simulator().path_to_magick, ffmpeg_path::Union{Missing,String}=simulator().path_to_ffmpeg, verbose::Bool=false,
     framerate::Union{Missing,Int}=missing, magick_density::Union{Missing,Int}=missing, magick_resize_x::Union{Missing,Int}=missing, magick_resize_y::Union{Missing,Int}=missing)
     assertInitialized()
     path_to_output_folder = joinpath(trialFolder(Simulation, simulation_id), "output")
@@ -120,3 +128,14 @@ function makeMovie(T::AbstractTrial; kwargs...)
 end
 
 makeMovie(T::PCMMOutput; kwargs...) = makeMovie(T.trial; kwargs...)
+
+function makeMovie(simulation_ids::AbstractVector{<:Integer}; kwargs...)
+    println("Making movies for $(length(simulation_ids)) simulations...")
+    for simulation_id in simulation_ids
+        print("  Making movie for simulation $simulation_id...")
+        makeMovie(simulation_id; kwargs...)
+        println("done.")
+    end
+end
+
+makeMovie(Ts::AbstractVector{<:AbstractTrial}; kwargs...) = makeMovie(simulationIDs(Ts); kwargs...)

--- a/test/test-scripts/MovieTests.jl
+++ b/test/test-scripts/MovieTests.jl
@@ -19,6 +19,10 @@ if Sys.isapple()
     @test makeMovie(custom_params_sim.id; framerate=10, magick_density=48, magick_resize_x=256, magick_resize_y=256)
     @test isfile(joinpath(PhysiCellModelManager.dataDir(), "outputs", "simulations", string(custom_params_sim.id), "output", "out.mp4"))
 
+    #! Batch over a range of IDs and a vector of Simulations (out.mp4 already exists for these, so each is a no-op)
+    @test makeMovie(1:1) |> isnothing
+    @test makeMovie(Simulation.(1:1)) |> isnothing
+
     #! Test that makeMovie returns false if no SVGs are found
     new_sim = Simulation(inputs, variation_id)
     out = run(new_sim)


### PR DESCRIPTION
## Summary

`makeMovie(4:7)` and `makeMovie(Simulation.(4:7))` previously threw `MethodError` — only the scalar `Int`, single `AbstractTrial`, and `PCMMOutput` forms existed. This adds batch dispatch over collections so these natural call forms work like the existing single-trial batching.

## Changes

- **`src/movie.jl`**
  - `makeMovie(::AbstractVector{<:Integer})` — loops over IDs (e.g. `4:7`, a `UnitRange`).
  - `makeMovie(::AbstractVector{<:AbstractTrial})` — flattens to IDs via `simulationIDs` and reuses the integer-vector path (e.g. `Simulation.(4:7)`).
  - Broadened the worker from `simulation_id::Int` to `::Integer`, since vector elements / `simulationIDs` output aren't guaranteed to be `Int`.
  - Updated docstring signature block, argument list, and examples.
- **`test/test-scripts/MovieTests.jl`** — added `makeMovie(1:1)` and `makeMovie(Simulation.(1:1))` coverage (no-ops returning `nothing`).
- **Docs/spec** — updated `PRD.md`, `progress.md` (2026-07-22 entry), and the Movies section of `docs/src/man/analyzing_output.md`.

## Verification

- Package precompiles cleanly.
- `which(makeMovie, …)` confirms correct dispatch for `4:7`, `Vector{Int}`, `Vector{Simulation}`, `Simulation`, and `Int`.
- The `MovieTests.jl` cases run on Apple with the PhysiCell binary present (CI), consistent with the existing movie tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)