### PR TITLE
Skip project auto-initialization while generating precompilation output

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -50,16 +50,22 @@
 - `createProject(path)` initializes a PCMM project folder with the canonical subdirectory layout and an SQLite database.
 - `initializeModelManager(path)` connects an existing PCMM project to the current Julia session; sets module-level globals.
 - After initialization, all subsequent PCMM calls operate relative to that project root.
+- `using PhysiCellModelManager` registers the module globals and then auto-initializes from the working directory. Whenever that succeeds — and therefore whenever the globals change — the initialization banner is printed.
+- Loading the package does **not** auto-initialize while Julia is generating a precompilation cache file or a system image.
 
 **Acceptance criteria:**
 - A fresh directory becomes a valid project after one `createProject` call.
 - Re-initializing an already-initialized project does not corrupt the database.
 - `databaseDiagnostics()` passes with no errors after initialization.
+- A redundant `__init__` in a process that already initialized a PCMM project is a no-op: the existing globals object and database handle are kept, not rebuilt.
+- Precompiling a package that depends on PCMM emits no banner and touches no project database.
 
 **Edge cases:**
 - Path does not exist → create it.
 - Path already contains a PCMM database → re-attach, do not reinitialize.
 - Called without any path → use current working directory.
+- Another ModelManager backend already owns `mm_globals_ref` → PCMM claims it and registers its own `PhysiCellSimulator`, rather than deferring and then running against a foreign simulator. (`ModelManagerGlobals` holds exactly one `simulator`, so the two backends cannot coexist in one process; the last one loaded wins.)
+- Loaded inside a precompilation subprocess → globals are registered (cheap, in-process) but no project is initialized, so `mm_globals()` still works for any downstream precompilation workload.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ julia> out = run(inputs, dv; n_replicates = 3) # 3 replicates per apoptosis rate
 ### Completed
 
 - [x] Project initialization (`createProject`, `initializeModelManager`)
+  - [x] Precompilation-safe loading — `using PhysiCellModelManager` auto-attaches to a project in the working directory, but skips it while Julia is writing a precompilation cache or system image, so precompiling a dependent package neither prints the banner nor opens a project database
 - [x] Model import from PhysiCell project folders (`importProject`, `InputFolders`)
   - [ ] Wizard for guiding users through the import process and recording their input folders
 - [x] Parameter variation — discrete, grid, distributed, latent, co-variation

--- a/docs/src/man/julia_environments.md
+++ b/docs/src/man/julia_environments.md
@@ -47,6 +47,16 @@ pkg> instantiate    # installs the exact versions recorded in Manifest.toml
 
 Committing these files alongside your `inputs` and `scripts` directories (see [Best practices](@ref best_practices_man)) is what makes a PhysiCellModelManager.jl project fully reproducible.
 
+## What happens when the package loads
+
+`using PhysiCellModelManager` looks for `PhysiCell/` and `data/` directories in the working directory Julia was launched from. If it finds them it attaches to that project and prints the logo and status banner; if it does not, it prints a short hint telling you to run [`createProject`](@ref) or [`initializeModelManager`](@ref). Either way you can attach to a project explicitly at any time:
+
+```julia-repl
+julia> initializeModelManager("path/to/project")
+```
+
+The banner appears each time the globals change, so it is a reliable signal of which project a session is pointed at.
+
 ## Learn more
 
 See the [Pkg.jl documentation](https://pkgdocs.julialang.org/v1/environments/) for the complete reference on environments.

--- a/progress.md
+++ b/progress.md
@@ -5,6 +5,39 @@
 
 ---
 
+## 2026-08-03 — Stop `__init__` from auto-initializing during precompilation
+
+### Motivation
+The logo + status banner was being printed repeatedly — apparently once per package in the environment that did `using PhysiCellModelManager`.
+
+### The premise was wrong, and that determined the fix
+Julia runs a module's `__init__` **at most once per process per load** (`run_module_init` is reached only from the cache-deserialization path in `loading.jl`; `canstart_loading` short-circuits an already-loaded module). Verified: loading three separate packages that each `using` a banner-printing base package ran `__init__` exactly once.
+
+The repeats came from **separate processes** — specifically the precompilation subprocess of each *dependent* package. Only the package being precompiled has its own `__init__` skipped; its dependencies are loaded normally, so PCMM's `__init__` runs in every such worker. Julia 1.12 hands the worker the same pipe for stdout and stderr and surfaces it, live when a single package was requested and otherwise replayed boxed under `┌ <DependentPkg>` — which is why it looked like the *other* package was printing.
+
+### Rejected: guarding on `mm_globals_ref` being non-`nothing`
+The first attempt was `!isnothing(ModelManager.mm_globals_ref[]) && isInitialized() && return`. It cannot work: `mm_globals_ref` is a `const Ref` initialized to `nothing` and PCMM's own `__init__` is its only assignment site, so in a fresh precompile worker it is always `nothing` and the guard falls through. Measured directly — every reproduced duplicate had `ref == nothing` on entry. It was also doubly narrow, since it additionally required `isInitialized()`, which is false in a worker whose working directory holds no project (the common case).
+
+Worse, keying on `mm_globals_ref` alone introduced a regression. `ModelManagerGlobals` holds exactly one `simulator`, and the ref is shared by every ModelManager backend. If another backend had already initialized, PCMM's `__init__` would return **before** registering its own `PhysiCellSimulator`, leaving PCMM running against a foreign one: `simulator().compiler` throws `FieldError`, and `runSimulation`/`setupMonad` dispatch to the other backend. On the base commit PCMM's unconditional assignment always won, so the guard only flipped *which* package silently lost.
+
+### Chosen: gate on `jl_generating_output`, and check the simulator type
+Two helpers in `src/PhysiCellModelManager.jl`:
+- `_generatingOutput()` — true exactly while a cache file or sysimage is being written. Verified true in the worker, false in a real session. `@static if isdefined(Base, :generating_output)` prefers Base's wrapper, falling back to `ccall(:jl_generating_output, Cint, ()) == 1`. Reviewer (Copilot) suggested that as a stability win over the raw `ccall`; that premise is wrong — `Base.generating_output` is neither exported nor `public` (`ispublic` false on 1.12.6), and called with no argument its body *is* that same `ccall` (`base/runtime_internals.jl`). Adopted anyway, on the weaker but real ground that Base then owns the mapping to the C entry point. Written `@static` rather than as a runtime ternary, matching `DocstringRefTests.jl`'s `@static if isdefined(Base, :ispublic)`. Behaviour re-verified after the swap: a pure `Pkg.precompile()` from inside a project directory stayed silent and left `data/` empty.
+- `_pcmmGlobalsRegistered()` — `!isnothing(globals) && globals.simulator isa PhysiCellSimulator && globals.initialized`. The simulator-type conjunct is what closes the multi-backend hole above.
+
+Ordering matters: the globals are registered *before* the `_generatingOutput()` return, because registering them is pure in-memory work and keeps `mm_globals()` usable by any `PrecompileTools` workload in a dependent package. Only `initializeModelManager()` — which resolves `PhysiCell`/`data` from `pwd()`, opens the database, and prints the banner — is skipped.
+
+### Side effect this fixes, beyond the noise
+Because the worker inherits the parent's working directory, precompiling an unrelated package *from inside a project folder* had PCMM open the real project. Demonstrated: a worker created `data/pcmm.db` (12 KB) in a directory containing bare `PhysiCell/` and `data/` folders. With a real project it would also run `resolvePackageVersion` (which has an auto-upgrade path) and `initializeDatabase()` schema writes from a throwaway process. Investigated and ruled out: the `@async databaseDiagnostics` task does *not* trigger Julia's `waiting for IO to finish` precompile warning — zero occurrences across three forced recompiles with a faithful stub; it only appears if the async body is slow.
+
+### On "if the globals change, that should print"
+Read as an implication, not a biconditional — so no change needed. `postInitDisplay` already prints whenever `initializeModelManager` succeeds, which is exactly when the globals change. In the two paths that now return early, nothing changes, so printing nothing is correct.
+
+### Open questions
+- Whether two ModelManager backends should ever coexist in one process. Today they cannot (one `simulator` field); PCMM now reliably claims the globals instead of silently deferring. If coexistence is ever wanted, `ModelManagerGlobals` needs a per-backend registry, which is a ModelManager change.
+
+---
+
 ## 2026-08-02 — Absorb ModelManager's docs-findability pass; declare PCMM's public API
 
 ### Motivation

--- a/src/PhysiCellModelManager.jl
+++ b/src/PhysiCellModelManager.jl
@@ -61,7 +61,66 @@ struct PCMMMissingProject <: Exception
     msg::String
 end
 
+"""
+    _pcmmGlobalsRegistered()
+
+Return `true` when [`ModelManager.mm_globals_ref`](@ref) already holds initialized globals whose
+simulator is a [`PhysiCellSimulator`](@ref) — that is, when PhysiCellModelManager.jl has already
+initialized a project in this Julia process.
+
+`mm_globals_ref` is shared by every ModelManager backend but holds only one `simulator`, so the
+simulator type must be checked too: if another backend owns the globals, PhysiCellModelManager.jl
+has to claim them rather than defer and then run against a foreign simulator.
+
+# Returns
+- `Bool`: `true` only if PhysiCellModelManager.jl owns initialized globals.
+
+# Examples
+```julia
+julia> using PhysiCellModelManager   # auto-initializes when a project is in the working directory
+
+julia> PhysiCellModelManager._pcmmGlobalsRegistered()
+true
+```
+"""
+function _pcmmGlobalsRegistered()
+    globals = ModelManager.mm_globals_ref[]
+    return !isnothing(globals) && globals.simulator isa PhysiCellSimulator && globals.initialized
+end
+
+#! `Base.generating_output()` is itself only `ccall(:jl_generating_output, ...) == 1` when called
+#! with no argument, and is unexported either way. Prefer it where it exists so Base owns the
+#! mapping to the C entry point, and fall back to the `ccall` on versions that predate it.
+@static if isdefined(Base, :generating_output)
+    _generatingOutput() = Base.generating_output()
+else
+    _generatingOutput() = ccall(:jl_generating_output, Cint, ()) == 1
+end
+
+"""
+    _generatingOutput()
+
+Return `true` while this Julia process is writing a precompilation cache file or a system image.
+
+`__init__` also runs inside the precompilation subprocess of every package that depends on
+PhysiCellModelManager.jl, so work with effects outside the process must be skipped there.
+
+# Returns
+- `Bool`: `true` if a cache file or system image is being generated.
+
+# Examples
+```julia
+julia> PhysiCellModelManager._generatingOutput()   # in an ordinary session
+false
+```
+"""
+_generatingOutput
+
 function __init__()
+    #! Nothing to do if we already own initialized globals. Deliberately keyed on the simulator
+    #! type as well: when another backend owns them, fall through and claim them for PhysiCell.
+    _pcmmGlobalsRegistered() && return
+
     sim = PhysiCellSimulator()
     sim.compiler = haskey(ENV, "PHYSICELL_CPP") ? ENV["PHYSICELL_CPP"] : "g++"
     sim.path_to_python = haskey(ENV, "PCMM_PYTHON_PATH") ? ENV["PCMM_PYTHON_PATH"] : missing
@@ -71,6 +130,13 @@ function __init__()
 
     n_parallel = haskey(ENV, "PCMM_NUM_PARALLEL_SIMS") ? parse(Int, ENV["PCMM_NUM_PARALLEL_SIMS"]) : 1
     ModelManager.mm_globals_ref[] = ModelManagerGlobals(simulator=sim, max_number_of_parallel_simulations=n_parallel)
+
+    #! Registering the globals above is pure in-memory work, so it is safe to do while a cache file
+    #! is being written — and keeps `mm_globals()` usable by any precompilation workload downstream.
+    #! Auto-initializing a project is not safe there: this `__init__` runs in the precompilation
+    #! subprocess of every dependent package, where it would open (and create) the database of
+    #! whatever project `pwd()` happens to contain and print the banner from a throwaway process.
+    _generatingOutput() && return
 
     try
         initializeModelManager()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,7 @@ test_order = [
     "VariationsTests.jl",
     "HPCTests.jl",
     "ModuleTests.jl",
+    "InitializationTests.jl",
     "PhysiCellVersionTests.jl",
     "PhysiCellStudioTests.jl",
     "DeletionTests.jl",

--- a/test/test-scripts/InitializationTests.jl
+++ b/test/test-scripts/InitializationTests.jl
@@ -1,0 +1,58 @@
+filename = @__FILE__
+filename = split(filename, "/") |> last
+str = "TESTING WITH $(filename)"
+hashBorderPrint(str)
+
+#! A foreign ModelManager backend, to stand in for another simulator package owning the globals.
+struct ForeignSimulator <: PhysiCellModelManager.ModelManager.AbstractSimulator end
+
+#! By this point in the suite a project is initialized and PhysiCellModelManager.jl owns the globals.
+@test PhysiCellModelManager.isInitialized()
+@test PhysiCellModelManager._pcmmGlobalsRegistered()
+
+#! The test suite is not writing a cache file or system image, so auto-initialization is not skipped.
+@test PhysiCellModelManager._generatingOutput() == false
+
+#! A redundant `__init__` is a no-op: the globals object and database handle are kept, not rebuilt.
+globals_before = PhysiCellModelManager.ModelManager.mm_globals_ref[]
+db_before = PhysiCellModelManager.centralDB()
+data_dir_before = PhysiCellModelManager.dataDir()
+physicell_dir_before = PhysiCellModelManager.physicellDir()
+
+PhysiCellModelManager.__init__()
+
+@test PhysiCellModelManager.ModelManager.mm_globals_ref[] === globals_before
+@test PhysiCellModelManager.centralDB() === db_before
+@test PhysiCellModelManager.dataDir() == data_dir_before
+@test PhysiCellModelManager.physicellDir() == physicell_dir_before
+@test PhysiCellModelManager.isInitialized()
+
+#! The guard must fall through in every state except "ours, and initialized", so that `__init__`
+#! claims the globals rather than running against a simulator it does not own.
+let ref = PhysiCellModelManager.ModelManager.mm_globals_ref
+    try
+        ref[] = nothing
+        @test PhysiCellModelManager._pcmmGlobalsRegistered() == false
+
+        #! Another backend, fully initialized: still must not short-circuit.
+        ref[] = ModelManagerGlobals(; simulator=ForeignSimulator(), initialized=true)
+        @test PhysiCellModelManager._pcmmGlobalsRegistered() == false
+
+        #! Ours, but initialization has not succeeded yet.
+        ours = ModelManagerGlobals(; simulator=PhysiCellSimulator())
+        ref[] = ours
+        @test ours.initialized == false
+        @test PhysiCellModelManager._pcmmGlobalsRegistered() == false
+
+        #! Ours and initialized: the only state that short-circuits.
+        ours.initialized = true
+        @test PhysiCellModelManager._pcmmGlobalsRegistered()
+    finally
+        ref[] = globals_before
+    end
+end
+
+#! The real project survived the swapping above.
+@test PhysiCellModelManager.isInitialized()
+@test PhysiCellModelManager.centralDB() === db_before
+@test PhysiCellModelManager.dataDir() == data_dir_before


### PR DESCRIPTION
Replaces #221 (closed). Rebased onto `main` as a single commit, so the guard that PR added never enters the history.

## What was actually happening

The repeated logo + status banner was **not** `__init__` running twice in one session. Julia runs a module's `__init__` at most once per process per load — `run_module_init` is reached only from the cache-deserialization path, and `canstart_loading` short-circuits an already-loaded module. Loading three separate packages that each `using` a banner-printing base package runs `__init__` exactly once.

The repeats come from **separate processes**: the precompilation subprocess of each *dependent* package. Only the package being precompiled has its own `__init__` skipped; its dependencies load normally, so PCMM's `__init__` runs in every worker. Julia 1.12 hands the worker one pipe for both stdout and stderr and surfaces it — live when a single package was requested, otherwise replayed boxed under `┌ <DependentPkg>`, which is why it looked like the *other* package was printing.

Reproduced with two stub packages depending on PCMM: the init output appeared once per worker plus once for the session.

## Why the `mm_globals_ref` approach in #221 could not work

`mm_globals_ref` is a `const Ref` initialized to `nothing`, and PCMM's own `__init__` is its only assignment site — so in a fresh precompilation worker it is always `nothing`. Measured directly: every reproduced duplicate had `ref == nothing` on entry, so that guard fell through and the banner printed anyway. It was also doubly narrow, additionally requiring `isInitialized()`, which is false in a worker whose working directory holds no project.

## This change

Two internal helpers in `src/PhysiCellModelManager.jl`:

- `_generatingOutput()` — true exactly while a cache file or sysimage is being written. `@static if isdefined(Base, :generating_output)` prefers Base's wrapper, falling back to `ccall(:jl_generating_output, Cint, ()) == 1` on versions that predate it. Note this is not an API-stability win — `Base.generating_output` is neither exported nor `public`, and with no argument its body *is* that same `ccall` — but it does let Base own the mapping to the C entry point. See the review thread.
- `_pcmmGlobalsRegistered()` — makes a redundant `__init__` a no-op. It checks `globals.simulator isa PhysiCellSimulator`, not merely that the ref is set, because `ModelManagerGlobals` holds a single `simulator` field shared by every ModelManager backend. Keying on the ref alone would let PCMM defer to another backend's globals and then run against a foreign simulator, where `simulator().compiler` throws `FieldError` and `runSimulation`/`setupMonad` dispatch elsewhere.

Ordering is deliberate: the globals are registered **before** the `_generatingOutput()` return, because that is pure in-memory work and keeps `mm_globals()` usable by any `PrecompileTools` workload in a dependent package. Only `initializeModelManager()` is skipped.

## Side effect this also fixes

The worker inherits the parent's working directory, so precompiling an unrelated package *from inside a project folder* had PCMM open the real project. Demonstrated: a worker created `data/pcmm.db` (12 KB) in a directory holding bare `PhysiCell/` and `data/` folders. With a real project it would also run `resolvePackageVersion` (auto-upgrade path) and `initializeDatabase()` schema writes from a throwaway process.

Investigated and ruled out: the `@async databaseDiagnostics` task does *not* trigger Julia's `waiting for IO to finish` precompile warning — zero occurrences across three forced recompiles with a faithful stub. It only appears if the async body is slow.

## Verification

| Check | Result |
|---|---|
| Package precompiles on rebased branch | clean |
| Guard predicate, all four `(ref, simulator, initialized)` states | 8/8 pass |
| Foreign initialized simulator → `__init__` claims globals | `simulator()` becomes `PhysiCellSimulator` |
| Own initialized globals → `__init__` no-op | ref identity preserved |
| Forced re-precompile of 2 dependents from inside a project dir | silent; `data/` left empty |
| `DocstringRefTests.jl` (new on `main`) | passes; both new docstrings are walked, and `PhysiCellSimulator` / `mm_globals_ref` are public |

`Pkg.test()` was **not** run locally — it needs `createProject` to clone PhysiCell and compile binaries, which is expected to fail off-runner. `InitializationTests.jl` is registered after `ModuleTests.jl`, the first point where a project is reliably initialized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
